### PR TITLE
Change URL getting public IP

### DIFF
--- a/poc-cb-net/cb-network.go
+++ b/poc-cb-net/cb-network.go
@@ -45,7 +45,7 @@ func NewCBNetwork(name string, port int) *CBNetwork {
 }
 
 func (cbnet *CBNetwork) inquiryVMPublicIP() {
-	resp, err := http.Get("http://icanhazip.com/")
+	resp, err := http.Get("https://ifconfig.co/")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
It's required because the previous URL sometimes takes time or fails to get public IP.