### PR TITLE
Improve the network update mechanism

### DIFF
--- a/poc-cb-net/cmd/server/server.go
+++ b/poc-cb-net/cmd/server/server.go
@@ -92,7 +92,7 @@ func WebsocketHandler(c echo.Context) error {
 
 	CBLogger.Infoln("The etcdClient is connected.")
 
-	CBLogger.Infof("Get - %v", etcdkey.NetworkingRule)
+	CBLogger.Debugf("Get - %v", etcdkey.NetworkingRule)
 	resp, etcdErr := etcdClient.Get(context.Background(), etcdkey.NetworkingRule, clientv3.WithPrefix())
 	if etcdErr != nil {
 		CBLogger.Error(etcdErr)

--- a/poc-cb-net/internal/app/pitcher-and-catcher.go
+++ b/poc-cb-net/internal/app/pitcher-and-catcher.go
@@ -35,8 +35,8 @@ func PitcherAndCatcher(CBNet *cbnet.CBNetwork, channel chan bool) {
 	fmt.Println("Blocked till Networking Rule setup")
 	<-channel
 
-	time.Sleep(time.Second * 1)
-	fmt.Println("Start PitcherAndCatcher")
+	fmt.Println("Start PitcherAndCatcher within 3 seconds")
+	time.Sleep(time.Second * 3)
 
 	rule := &CBNet.NetworkingRules
 	index := rule.GetIndexOfPublicIP(CBNet.MyPublicIP)

--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 )
 
 // I use TUN interface, so only plain IP packet, no ethernet header + mtu is set to 1300
@@ -31,6 +32,7 @@ const (
 
 // CBLogger represents a logger to show execution processes according to the logging level.
 var CBLogger *logrus.Logger
+var mutex = new(sync.Mutex)
 
 func init() {
 	// cblog is a global variable.
@@ -224,7 +226,11 @@ func (cbnetwork CBNetwork) GetHostNetworkInformation() dataobjects.HostNetworkIn
 func (cbnetwork *CBNetwork) SetNetworkingRules(rules dataobjects.NetworkingRule) {
 	CBLogger.Debug("Start.........")
 
+	CBLogger.Debug("Lock to update the networking rule")
+	mutex.Lock()
 	cbnetwork.NetworkingRules = rules
+	CBLogger.Debug("Unlock to update the networking rule")
+	mutex.Unlock()
 
 	CBLogger.Debug("End.........")
 }
@@ -296,8 +302,8 @@ func (cbnetwork *CBNetwork) StartCBNetworking(channel chan bool) {
 	CBLogger.Info("Run CBNetworking between VMs")
 
 	cbnetwork.initCBNet()
-	channel <- true
 	cbnetwork.isRunning = true
+	//channel <- true
 
 	CBLogger.Debug("End.........")
 }
@@ -397,7 +403,7 @@ func (cbnetwork *CBNetwork) RunTunneling(channel chan bool) {
 	CBLogger.Debug("Start.........")
 
 	CBLogger.Debug("Blocked till Networking Rule setup")
-	<-channel
+	//<-channel
 
 	CBLogger.Debug("Start decapsulation")
 	// Decapsulation


### PR DESCRIPTION
- Replace "watch > get host network information > put" with "get > watch with rev > get host network information > compare and swap"
- Remove channel value
- Add mutext lock to securely update the networking rule
- Add sleep before starting PitcherAndCatcher application
- Perform linting