### PR TITLE
Containerize the cb-network controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+## This is a Dockerfile for cb-network server
+
+##############################################################
+## Stage 1 - Go Build
+##############################################################
+
+FROM golang:1.15.3 AS builder
+
+ENV GO111MODULE=on
+
+COPY . /cb-larva
+
+WORKDIR /cb-larva/poc-cb-net/cmd/server/
+
+# RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o server .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o server
+
+#############################################################
+## Stage 2 - Application Setup
+##############################################################
+
+FROM alpine:latest
+
+WORKDIR /app
+
+RUN mkdir configs
+
+COPY --from=builder /cb-larva .
+
+# A port of Admin Web for the cb-network controller
+EXPOSE 9999
+
+WORKDIR /app/poc-cb-net/cmd/server
+
+ENTRYPOINT ["./server"]

--- a/poc-cb-net/internal/app/pitcher-and-catcher.go
+++ b/poc-cb-net/internal/app/pitcher-and-catcher.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -31,7 +32,8 @@ func MessageCatcher(conn *net.UDPConn) {
 }
 
 // PitcherAndCatcher represents a function to send messages continuously.
-func PitcherAndCatcher(CBNet *cbnet.CBNetwork, channel chan bool) {
+func PitcherAndCatcher(wg *sync.WaitGroup, CBNet *cbnet.CBNetwork, channel chan bool) {
+	defer wg.Done()
 	fmt.Println("Block pitching anc catching till networking rule setup")
 	<-channel
 

--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -383,7 +383,8 @@ func (cbnetwork *CBNetwork) StartCBNetworking(channel chan bool) (int, error) {
 //}
 
 // RunTunneling represents a function to be performing tunneling between hosts (e.g., VMs).
-func (cbnetwork *CBNetwork) RunTunneling(channel chan bool) {
+func (cbnetwork *CBNetwork) RunTunneling(wg *sync.WaitGroup, channel chan bool) {
+	defer wg.Done()
 	CBLogger.Debug("Start.........")
 
 	CBLogger.Debug("Blocked till Networking Rule setup")

--- a/poc-cb-net/internal/file/file.go
+++ b/poc-cb-net/internal/file/file.go
@@ -1,0 +1,13 @@
+package file
+
+import "os"
+
+// Exists checks if a file exists and is not a directory before we
+// try using it to prevent further errors.
+func Exists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}


### PR DESCRIPTION
- Read configs from two paths
  - Load configs from the path ./configs/ (for container-based execution)
  - Load configs from the path ../../configs/ (for source code based execution)
- Add a Dockerfile to build a container image for the cb-network controller
- Add WaitGroup to wait for all goroutines to finish (necessary for detached mode container)
- Add the file package including Exist() to check if the file exists or not