### PR TITLE
Utilize CLADNet's configuration information created by users

### DIFF
--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -109,7 +109,7 @@ func main() {
 		arg = os.Args[1]
 	}
 
-	var CLADNetID = "CLADNet1"
+	var CLADNetID = "c2eau8atiahtscepc2dg"
 	var hostID = "host1"
 
 	// Wait for multiple goroutines to complete

--- a/poc-cb-net/web/public/index.html
+++ b/poc-cb-net/web/public/index.html
@@ -314,7 +314,7 @@
     function buildChartData(json) {
         // Another loop gonna be added to show multi-CLADNet
         let obj = {
-            name: json.CLADNetID,
+            name: "CLADNet (" + json.CLADNetID + ")",
             data: []
         };
 


### PR DESCRIPTION
- Get CLADNet's configuration information by CLADNet ID
- Use a network CIDR block to assign an IP for a host(VM)