### PR TITLE
Install golangci-lint by a script

### DIFF
--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install golangci-lint
-        run: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.35.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.0
 
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run


### PR DESCRIPTION
- Change installation method from "go get" to "install.sh" script