### PR TITLE
Updated the Go version from 1.15.x to 1.16.x

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.15.x ]
+        go-version: [ 1.16.x ]
         os: [ ubuntu-18.04 ] #macos-latest, windows-latest
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.15.x ]
+        go-version: [ 1.16.x ]
         os: [ ubuntu-18.04 ] #macos-latest, windows-latest
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Updated the Go version on workflows from 1.15.x to 1.16.x

Files having the change
- build-on-pull-request.yaml
- lint-on-push.yml