### PR TITLE
Add descending order func for map and fix a bug

### DIFF
--- a/poc-cb-net/cmd/service/cladnet-service.go
+++ b/poc-cb-net/cmd/service/cladnet-service.go
@@ -213,6 +213,7 @@ func (s *server) CreateCLADNet(ctx context.Context, cladnetSpec *pb.CLADNetSpeci
 }
 
 func (s *server) RecommendAvailableIPv4PrivateAddressSpaces(ctx context.Context, ipnets *pb.IPNetworks) (*pb.AvailableIPv4PrivateAddressSpaces, error) {
+	log.Printf("Received: %v", ipnets.IpNetworks)
 
 	availableSpaces := nethelper.GetAvailableIPv4PrivateAddressSpaces(ipnets.IpNetworks)
 	response := &pb.AvailableIPv4PrivateAddressSpaces{

--- a/poc-cb-net/cmd/test-client/test-client.go
+++ b/poc-cb-net/cmd/test-client/test-client.go
@@ -12,7 +12,7 @@ import (
 func main() {
 
 	// gRPC section
-	grpcConn, err := grpc.Dial("localhost:8088", grpc.WithInsecure(), grpc.WithBlock())
+	grpcConn, err := grpc.Dial("localhost:8089", grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		log.Fatalf("Cannot connect: %v", err)
 	}
@@ -24,15 +24,25 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	ret, err := cladnetClient.CreateCLADNet(ctx, &pb.CLADNetSpecification{
+	ipNetworks := &pb.IPNetworks{IpNetworks: []string{"10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24", "172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24", "192.168.1.0/28", "192.168.2.0/28", "192.168.3.0/28", "192.168.4.0/28", "192.168.5.0/28", "192.168.6.0/28", "192.168.7.0/28"}}
+
+	ret1, err := cladnetClient.RecommendAvailableIPv4PrivateAddressSpaces(ctx, ipNetworks)
+	if err != nil {
+		log.Fatalf("could not request: %v", err)
+	}
+	log.Printf("RecommendedIpv4PrivateAddressSpace: %v", ret1.RecommendedIpv4PrivateAddressSpace)
+
+	cladnetSpec := &pb.CLADNetSpecification{
 		Id:               "",
 		Name:             "CLADNet01",
-		Ipv4AddressSpace: "192.168.77.0/26",
-		Description:      "Alvin's CLADNet01"})
+		Ipv4AddressSpace: ret1.RecommendedIpv4PrivateAddressSpace,
+		Description:      "Alvin's CLADNet01"}
+
+	ret2, err := cladnetClient.CreateCLADNet(ctx, cladnetSpec)
 
 	if err != nil {
 		log.Fatalf("could not request: %v", err)
 	}
 
-	log.Printf("Config: %v", ret)
+	log.Printf("Config: %v", ret2)
 }


### PR DESCRIPTION
Resolve #142, #149

- Add getDescendingOrderedKeysOfMap() and update related code blocks because the ordering is not supported for the Go map
- Fix bug related to the assignment of a recommended IPv4 private address space