### PR TITLE
Add an example to test-client and update Makefile

### DIFF
--- a/poc-cb-net/Makefile
+++ b/poc-cb-net/Makefile
@@ -1,9 +1,24 @@
-default:
+
+default: 
+	@echo "Build"
 	go build -mod=mod -o ./cmd/admin-web/admin-web ./cmd/admin-web/admin-web.go
 	go build -mod=mod -o ./cmd/agent/agent ./cmd/agent/agent.go
 	go build -mod=mod -o ./cmd/controller/controller ./cmd/controller/controller.go
 	go build -mod=mod -o ./cmd/service/cladnet-service ./cmd/service/cladnet-service.go
 	go build -mod=mod -o ./cmd/test-client/test-client ./cmd/test-client/test-client.go
+	
+production: 
+	@echo "Build for production"
+# Note - Using cgo write normal Go code that imports a pseudo-package "C". I may not need on cross-compiling.
+# Note - You can find possible platforms by 'go tool dist list' for GOOS and GOARCH
+# Note - Using the -ldflags parameter can help set variable values at compile time.
+# Note - Using the -s and -w linker flags can strip the debugging information.
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o ./cmd/admin-web/admin-web ./cmd/admin-web/admin-web.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o ./cmd/agent/agent ./cmd/agent/agent.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o ./cmd/controller/controller ./cmd/controller/controller.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o ./cmd/service/cladnet-service ./cmd/service/cladnet-service.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o ./cmd/test-client/test-client ./cmd/test-client/test-client.go
+
 # cc:
 #  	GOOS=linux GOARCH=arm go build -mod=mod -o cb-tumblebug-arm
 # swag swagger:

--- a/poc-cb-net/cmd/test-client/test-client.go
+++ b/poc-cb-net/cmd/test-client/test-client.go
@@ -5,44 +5,91 @@ import (
 	"log"
 	"time"
 
+	model "github.com/cloud-barista/cb-larva/poc-cb-net/internal/cb-network/model"
 	pb "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/api/gen/go/cbnetwork"
 	"google.golang.org/grpc"
 )
 
-func main() {
+func createProperCloudAdaptiveNetwork(gRPCServiceEndpoint string, ipNetworks []string, cladnetName string, cladnetDescription string) (model.CLADNetSpecification, error) {
 
-	// gRPC section
-	grpcConn, err := grpc.Dial("localhost:8089", grpc.WithInsecure(), grpc.WithBlock())
+	ipNets := &pb.IPNetworks{IpNetworks: ipNetworks}
+
+	// Connect to the gRPC server
+	grpcConn, err := grpc.Dial(gRPCServiceEndpoint, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
-		log.Fatalf("Cannot connect: %v", err)
+		log.Printf("Cannot connect: %v\n", err)
+		return model.CLADNetSpecification{}, err
 	}
 	defer grpcConn.Close()
 
+	// Create a stub of Cloud AdaptiveNetwork
 	cladnetClient := pb.NewCloudAdaptiveNetworkClient(grpcConn)
 
-	// Request/call CreateCLADNnet()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	ipNetworks := &pb.IPNetworks{IpNetworks: []string{"10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24", "172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24", "192.168.1.0/28", "192.168.2.0/28", "192.168.3.0/28", "192.168.4.0/28", "192.168.5.0/28", "192.168.6.0/28", "192.168.7.0/28"}}
-
-	ret1, err := cladnetClient.RecommendAvailableIPv4PrivateAddressSpaces(ctx, ipNetworks)
+	// Call rpc, RecommendAvailableIPv4PrivateAddressSpaces(ctx, ipNets)
+	availableIPv4PrivateAddressSpaces, err := cladnetClient.RecommendAvailableIPv4PrivateAddressSpaces(ctx, ipNets)
 	if err != nil {
-		log.Fatalf("could not request: %v", err)
+		log.Printf("Could not request: %v\n", err)
+		return model.CLADNetSpecification{}, err
 	}
-	log.Printf("RecommendedIpv4PrivateAddressSpace: %v", ret1.RecommendedIpv4PrivateAddressSpace)
+	log.Printf("RecommendedIpv4PrivateAddressSpace: %#v", availableIPv4PrivateAddressSpaces.RecommendedIpv4PrivateAddressSpace)
 
-	cladnetSpec := &pb.CLADNetSpecification{
+	// Call rpc, CreateCLADNet(ctx, cladnetSpec)
+	reqCladnetSpec := &pb.CLADNetSpecification{
 		Id:               "",
-		Name:             "CLADNet01",
-		Ipv4AddressSpace: ret1.RecommendedIpv4PrivateAddressSpace,
-		Description:      "Alvin's CLADNet01"}
+		Name:             cladnetName,
+		Ipv4AddressSpace: availableIPv4PrivateAddressSpaces.RecommendedIpv4PrivateAddressSpace,
+		Description:      cladnetDescription}
 
-	ret2, err := cladnetClient.CreateCLADNet(ctx, cladnetSpec)
-
+	cladnetSpec, err := cladnetClient.CreateCLADNet(ctx, reqCladnetSpec)
 	if err != nil {
-		log.Fatalf("could not request: %v", err)
+		log.Printf("Could not request: %v", err)
+		return model.CLADNetSpecification{}, err
 	}
 
-	log.Printf("Config: %v", ret2)
+	log.Printf("Struct: %#v", cladnetSpec)
+
+	spec := model.CLADNetSpecification{
+		ID:               cladnetSpec.Id,
+		Name:             cladnetSpec.Name,
+		Ipv4AddressSpace: cladnetSpec.Ipv4AddressSpace,
+		Description:      cladnetSpec.Description,
+	}
+	return spec, nil
+}
+
+func main() {
+
+	gRPCServiceEndpoint := "localhost:8089"
+	dummyIPNetworks := []string{"10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24", "172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24", "192.168.1.0/28", "192.168.2.0/28", "192.168.3.0/28", "192.168.4.0/28", "192.168.5.0/28", "192.168.6.0/28", "192.168.7.0/28"}
+
+	cladnetName := "CLADNet01"
+	cladnetDescription := "Alvin's CLADNet01"
+
+	// Step 1: Create a cloud daptive network and get an ID of it.
+
+	cladnetSpec, err := createProperCloudAdaptiveNetwork(gRPCServiceEndpoint, dummyIPNetworks, cladnetName, cladnetDescription)
+	if err != nil {
+		log.Printf("Could not create a cloud adaptive network: %v\n", err)
+	}
+
+	log.Printf("Struct: %#v\n", cladnetSpec)
+
+	// Step 2: Deploy cb-network agent to hosts with ${ETCD_HOSTS}, ${CLADNet_ID}, and ${VMID}
+	// An example step from a CB-Tumblebug script
+	// 	BuildAndRunCBNetworkAgentCMD="wget https://raw.githubusercontent.com/cloud-barista/cb-larva/main/poc-cb-net/scripts/build-and-run-agent-in-the-background.sh -O ~/build-and-run-agent-in-the-background.sh;
+	//		chmod +x ~/build-and-run-agent-in-the-background.sh;
+	// 		~/build-and-run-agent-in-the-background.sh '${ETCD_HOSTS}' ${CLADNET_ID} ${VMID}"
+	//
+	//     echo "CMD: ${BuildAndRunCBNetworkAgentCMD}"
+	//
+	//     VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
+	//         {
+	//         "command"        : "${BuildAndRunCBNetworkAgentCMD}"
+	//         }
+	// EOF
+	//     )
+
 }

--- a/poc-cb-net/config/template-config.yaml
+++ b/poc-cb-net/config/template-config.yaml
@@ -10,7 +10,7 @@ admin_web:
 # A config for the cb-network agent as follows:
 cb_network:
   cladnet_id: "xxxx"
-  host_id: "xxxx"
+  host_id: "" # if host_id is "" (empty string), the cb-network agent will use hostname.
 
 # A config for the grpc as follows:
 grpc:

--- a/poc-cb-net/internal/network-helper/network-helper.go
+++ b/poc-cb-net/internal/network-helper/network-helper.go
@@ -100,7 +100,7 @@ func getDescendingOrderedKeysOfMap(m map[int]bool) []int {
 	sortedKeys := make([]int, 0, len(m))
 
 	for k := range m {
-		fmt.Println("k", k)
+		// fmt.Println("k", k)
 		sortedKeys = append(sortedKeys, k)
 	}
 


### PR DESCRIPTION
- Add an example for creating a cloud adaptive network to test-client
- Add a target(`production`) to Makefile for generating reduced-size binaries