### PR TITLE
Update the binary link for the cb-network agent

### DIFF
--- a/poc-cb-net/cmd/test-client/demo-client.go
+++ b/poc-cb-net/cmd/test-client/demo-client.go
@@ -626,10 +626,6 @@ func main() {
 	{
 		"commonImage": "ubuntu18.04",
 		"commonSpec": "gcp-asia-east1-e2-standard-2"
-	},
-	{
-		"commonImage": "ubuntu18.04",
-		"commonSpec": "alibaba-ap-northeast-1-ecs-t5-lc1m2-large"
 	}
 	]
 }`

--- a/poc-cb-net/scripts/1.deploy-cb-network-agent.sh
+++ b/poc-cb-net/scripts/1.deploy-cb-network-agent.sh
@@ -28,8 +28,8 @@ mkdir ~/cb-network-agent
 cd ~/cb-network-agent
 
 
-# Get the execution file of the cb-network agent 0.0.6
-wget -q https://github.com/cloud-barista/cb-larva/releases/download/v0.0.6/agent
+# Get the execution file of the cb-network agent
+wget -q https://github.com/cloud-barista/cb-larva/releases/download/v0.0.7/agent
 ls -al agent
 
 # Change mode

--- a/poc-cb-net/scripts/2.re-deploy-cb-network-agent.sh
+++ b/poc-cb-net/scripts/2.re-deploy-cb-network-agent.sh
@@ -35,8 +35,8 @@ mkdir ~/cb-network-agent
 cd ~/cb-network-agent
 
 
-# Get the execution file of the cb-network agent 0.0.6
-wget -q https://github.com/cloud-barista/cb-larva/releases/download/v0.0.6/agent
+# Get the execution file of the cb-network agent
+wget -q https://github.com/cloud-barista/cb-larva/releases/download/v0.0.7/agent
 ls -al agent
 
 # Change mode

--- a/poc-cb-net/scripts/get-and-run-agent.sh
+++ b/poc-cb-net/scripts/get-and-run-agent.sh
@@ -28,8 +28,8 @@ mkdir ~/cb-network-agent
 cd ~/cb-network-agent
 
 
-# Get the execution file of the cb-network agent 0.0.6
-wget -q https://github.com/cloud-barista/cb-larva/releases/download/v0.0.6/agent
+# Get the execution file of the cb-network agent
+wget -q https://github.com/cloud-barista/cb-larva/releases/download/v0.0.7/agent
 ls -al agent
 
 # Change mode


### PR DESCRIPTION
- From `https://github.com/cloud-barista/cb-larva/releases/download/v0.0.6/agent`
to `https://github.com/cloud-barista/cb-larva/releases/download/v0.0.7/agent`