### PR TITLE
Ignore protos and protobuffers from lint test workflow

### DIFF
--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -15,7 +15,8 @@ on:
     # Ignoring paths
     paths-ignore:
       # Push events to poc-cb-net/archive/**
-      - 'poc-cb-net/archive/**'    
+      - 'poc-cb-net/archive/**'
+      - 'poc-cb-net/pkg/api/**'
       - '**.md'
       - '.gitignore'
       - 'LICENSE'


### PR DESCRIPTION
fix #173 
- Delete whitespaces at `poc-cb-net/archive/**`
- Add `poc-cb-net/pkg/api/**` to paths-ignore