### PR TITLE
Control the agents remotely

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16 ]
         os: [ ubuntu-18.04 ] #macos-latest, windows-latest
     runs-on: ${{ matrix.os }}
 
@@ -30,7 +30,7 @@ jobs:
       #     optionally downloading and caching a version of Go by version and adding to PATH
       #     registering problem matchers for error output
       # This step uses GitHub's setup-go: https://github.com/actions/setup-go
-      - name: Set up Go 1.x
+      - name: Set up Go 1.16.x
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -30,11 +30,17 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [ 1.16 ]
         os: [ ubuntu-18.04 ] #macos-latest, windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
       - name: Checkout source code
         uses: actions/checkout@v2
 

--- a/poc-cb-net/cmd/admin-web/admin-web.go
+++ b/poc-cb-net/cmd/admin-web/admin-web.go
@@ -177,7 +177,7 @@ func cladnetSpecificationHandler(etcdClient *clientv3.Client, responseText []byt
 	CBLogger.Debug("Start.........")
 
 	// Unmarshal the specification of Cloud Adaptive Network (CLADNet)
-	// :IPv4 CIDR block, Description
+	// :IPv4 Network, Description
 
 	var tempSpec model.CLADNetSpecification
 	errUnmarshal := json.Unmarshal(responseText, &tempSpec)

--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -211,10 +211,10 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 					} else {
 						// Assign a candidate of IP Address in serial order to a host
 						// Exclude Network Address, Broadcast Address, Gateway Address
-						hostIPCIDRBlock, hostIPAddress := assignIPAddressToHost(cladnetIpv4AddressSpace, uint32(len(tempRule.HostID)+2))
+						hostIPv4Network, hostIPAddress := assignIPAddressToHost(cladnetIpv4AddressSpace, uint32(len(tempRule.HostID)+2))
 
-						// Append {HostID, HostIPCIDRBlock, HostIPAddress, PublicIP} to a CLADNet's Networking Rule
-						tempRule.AppendRule(parsedHostID, hostIPCIDRBlock, hostIPAddress, hostNetworkInformation.PublicIP)
+						// Append {HostID, HostIPv4Network, HostIPAddress, PublicIP} to a CLADNet's Networking Rule
+						tempRule.AppendRule(parsedHostID, hostIPv4Network, hostIPAddress, hostNetworkInformation.PublicIP)
 					}
 
 					CBLogger.Debugf("Put \"%v\"", keyNetworkingRuleOfCLADNet)
@@ -301,15 +301,15 @@ func getIpv4AddressSpace(etcdClient *clientv3.Client, key string) (string, error
 			CBLogger.Error(errUnmarshal)
 		}
 		CBLogger.Tracef("TempSpec: %v", tempSpec)
-		// Get a network CIDR block of CLADNet
+		// Get an IPv4 address space of CLADNet
 		return tempSpec.Ipv4AddressSpace, nil
 	}
 	return "", errors.New("No CLADNet exists")
 }
 
-func assignIPAddressToHost(cidrBlock string, numberOfIPsAssigned uint32) (string, string) {
+func assignIPAddressToHost(ipNetwork string, numberOfIPsAssigned uint32) (string, string) {
 	// Get IPNet struct from string
-	_, ipv4Net, errParseCIDR := net.ParseCIDR(cidrBlock)
+	_, ipv4Net, errParseCIDR := net.ParseCIDR(ipNetwork)
 	if errParseCIDR != nil {
 		CBLogger.Error(errParseCIDR)
 	}
@@ -344,11 +344,11 @@ func assignIPAddressToHost(cidrBlock string, numberOfIPsAssigned uint32) (string
 	// Get CIDR Prefix
 	cidrPrefix, _ := ipv4Net.Mask.Size()
 	// Create Host IP CIDR Block
-	hostIPCIDRBlock := fmt.Sprint(ip, "/", cidrPrefix)
+	hostIPv4Network := fmt.Sprint(ip, "/", cidrPrefix)
 	// To string IP Address
 	hostIPAddress := fmt.Sprint(ip)
 
-	return hostIPCIDRBlock, hostIPAddress
+	return hostIPv4Network, hostIPAddress
 }
 
 func main() {

--- a/poc-cb-net/internal/app/pitcher-and-catcher.go
+++ b/poc-cb-net/internal/app/pitcher-and-catcher.go
@@ -2,12 +2,13 @@ package app
 
 import (
 	"fmt"
-	"github.com/cloud-barista/cb-larva/poc-cb-net/internal/cb-network"
 	"log"
 	"net"
 	"os"
 	"sync"
 	"time"
+
+	cbnet "github.com/cloud-barista/cb-larva/poc-cb-net/internal/cb-network"
 )
 
 /* A Simple function to verify error */
@@ -41,7 +42,7 @@ func PitcherAndCatcher(wg *sync.WaitGroup, CBNet *cbnet.CBNetwork, channel chan 
 	time.Sleep(time.Second * 3)
 
 	rule := CBNet.NetworkingRules
-	index := rule.GetIndexOfPublicIP(CBNet.MyPublicIP)
+	index := rule.GetIndexOfPublicIP(CBNet.HostPublicIP)
 	myCBNetIP := rule.HostIPAddress[index]
 	// Catcher
 	// Prepare a server address at any address at port 10001
@@ -78,7 +79,7 @@ func PitcherAndCatcher(wg *sync.WaitGroup, CBNet *cbnet.CBNetwork, channel chan 
 			des := rule.PublicIPAddress[index]
 
 			// Skip self pitching
-			if des == CBNet.MyPublicIP {
+			if des == CBNet.HostPublicIP {
 				//log.Println("It's mine. Continue")
 				continue
 			}

--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -356,8 +356,8 @@ func (cbnetwork *CBNetwork) StartCBNetworking() (int, error) {
 }
 
 // RunTunneling represents a function to be performing tunneling between hosts (e.g., VMs).
-func (cbnetwork *CBNetwork) RunTunneling(wg *sync.WaitGroup) {
-	defer wg.Done()
+func (cbnetwork *CBNetwork) RunTunneling() {
+	// defer wg.Done()
 	CBLogger.Debug("Start.........")
 
 	CBLogger.Debug("Blocked till Networking Rule setup")

--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -178,7 +178,7 @@ func (cbnetwork *CBNetwork) getPrivateIPv4Networks() {
 	// Recursively get network interface information
 	for _, iface := range ifaces {
 		// Print a network interface name
-		CBLogger.Debug("Interface name:", iface.Name)
+		CBLogger.Trace("Interface name:", iface.Name)
 
 		// Declare a NetworkInterface variable
 		var networkInterface model.NetworkInterface

--- a/poc-cb-net/internal/cb-network/model/host-network-information.go
+++ b/poc-cb-net/internal/cb-network/model/host-network-information.go
@@ -2,6 +2,6 @@ package cbnet
 
 // HostNetworkInformation represents the network information of VM, such as public IP and private networks
 type HostNetworkInformation struct {
-	PublicIP                 string   `json:"publicIPAddress"`
-	PrivateNetworkCIDRBlocks []string `json:"privateNetworkCIDRBlocks"`
+	PublicIP            string   `json:"publicIPAddress"`
+	PrivateIPv4Networks []string `json:"privateIPv4Networks"`
 }

--- a/poc-cb-net/internal/cb-network/model/network-interface.go
+++ b/poc-cb-net/internal/cb-network/model/network-interface.go
@@ -2,9 +2,9 @@ package cbnet
 
 // IP represents a set of information related to IP address
 type IP struct {
-	Version   string `json:"Version"`
-	IPAddress string `json:"IP"`
-	CIDRBlock string `json:"CIDRBlock"`
+	Version     string `json:"Version"`
+	IPAddress   string `json:"IP"`
+	IPv4Network string `json:"IPv4Network"`
 }
 
 // NetworkInterface represents a network interface in a system with assigned IPs (Typically IPv4, and IPv6)

--- a/poc-cb-net/internal/cb-network/model/networking-rule.go
+++ b/poc-cb-net/internal/cb-network/model/networking-rule.go
@@ -2,13 +2,14 @@ package cbnet
 
 import (
 	"fmt"
-	"github.com/cloud-barista/cb-larva/poc-cb-net/internal/file"
-	cblog "github.com/cloud-barista/cb-log"
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/cloud-barista/cb-larva/poc-cb-net/internal/file"
+	cblog "github.com/cloud-barista/cb-log"
+	"github.com/sirupsen/logrus"
 )
 
 // CBLogger represents a logger to show execution processes according to the logging level.
@@ -44,7 +45,7 @@ func init() {
 type NetworkingRule struct {
 	CLADNetID       string   `json:"CLADNetID"`
 	HostID          []string `json:"hostID"`
-	HostIPCIDRBlock []string `json:"hostIPCIDRBlock"`
+	HostIPv4Network []string `json:"hostIPv4Network"`
 	HostIPAddress   []string `json:"hostIPAddress"`
 	PublicIPAddress []string `json:"publicIPAddress"`
 }
@@ -54,19 +55,19 @@ func (netrule *NetworkingRule) AppendRule(ID string, CBNet string, CBNetIP strin
 	CBLogger.Infof("A rule: {%s, %s, %s, %s}", ID, CBNet, CBNetIP, PublicIP)
 	if !netrule.Contain(ID) { // If HostID doesn't exists, append rule
 		netrule.HostID = append(netrule.HostID, ID)
-		netrule.HostIPCIDRBlock = append(netrule.HostIPCIDRBlock, CBNet)
+		netrule.HostIPv4Network = append(netrule.HostIPv4Network, CBNet)
 		netrule.HostIPAddress = append(netrule.HostIPAddress, CBNetIP)
 		netrule.PublicIPAddress = append(netrule.PublicIPAddress, PublicIP)
 	}
 }
 
 // UpdateRule represents a function to update a rule to the NetworkingRule
-func (netrule *NetworkingRule) UpdateRule(id string, hostIPCIDRBlock string, hostIPAddress string, publicIP string) {
-	CBLogger.Infof("A rule: {%s, %s, %s, %s}", id, hostIPCIDRBlock, hostIPAddress, publicIP)
+func (netrule *NetworkingRule) UpdateRule(id string, hostIPv4Network string, hostIPAddress string, publicIP string) {
+	CBLogger.Infof("A rule: {%s, %s, %s, %s}", id, hostIPv4Network, hostIPAddress, publicIP)
 	if netrule.Contain(id) { // If HostID exists, update rule
 		index := netrule.GetIndexOfID(id)
-		if hostIPCIDRBlock != "" {
-			netrule.HostIPCIDRBlock[index] = hostIPCIDRBlock
+		if hostIPv4Network != "" {
+			netrule.HostIPv4Network[index] = hostIPv4Network
 		}
 		if hostIPAddress != "" {
 			netrule.HostIPAddress[index] = hostIPAddress
@@ -80,9 +81,9 @@ func (netrule NetworkingRule) GetIndexOfID(id string) int {
 	return netrule.find(netrule.HostID, id)
 }
 
-// GetIndexOfCBNet represents a function to find and return an index of HostIPCIDRBlock from NetworkingRule
-func (netrule NetworkingRule) GetIndexOfCBNet(hostIPCIDRBlock string) int {
-	return netrule.find(netrule.HostIPCIDRBlock, hostIPCIDRBlock)
+// GetIndexOfCBNet represents a function to find and return an index of HostIPv4Network from NetworkingRule
+func (netrule NetworkingRule) GetIndexOfCBNet(hostIPv4Network string) int {
+	return netrule.find(netrule.HostIPv4Network, hostIPv4Network)
 }
 
 // GetIndexOfCBNetIP represents a function to find and return an index of HostIPAddress from NetworkingRule

--- a/poc-cb-net/internal/command/command.go
+++ b/poc-cb-net/internal/command/command.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	Resume            = "resume"
+	Suspend           = "suspend"
+	CheckConnectivity = "check-connectivity"
+)
+
+var placeHolder = `{"controlCommand": "%s", "controlCommandOption": "%s"}`
+
+func BuildMessageBody(controlCommand string, controlCommandOption string) string {
+	return fmt.Sprintf(placeHolder, controlCommand, controlCommandOption)
+}
+
+func ParseMessageBody(message string) (string, string) {
+	cmd := gjson.Get(message, "controlCommand").String()
+	cmdOption := gjson.Get(message, "controlCommandOption").String()
+	return cmd, cmdOption
+}

--- a/poc-cb-net/internal/etcd-key/etcd-key.go
+++ b/poc-cb-net/internal/etcd-key/etcd-key.go
@@ -4,13 +4,15 @@ const (
 	// CloudAdaptiveNetwork is a constant variable of "/registry/cloud-adaptive-network" key
 	CloudAdaptiveNetwork = "/registry/cloud-adaptive-network"
 	// CLADNetSpecification is a constant variable of "/registry/cloud-adaptive-network/cladnet-specification" key
-	CLADNetSpecification = "/registry/cloud-adaptive-network/cladnet-specification"
+	CLADNetSpecification = CloudAdaptiveNetwork + "/cladnet-specification"
 	// HostNetworkInformation is a constant variable of "/registry/cloud-adaptive-network/host-network-information" key
-	HostNetworkInformation = "/registry/cloud-adaptive-network/host-network-information"
+	HostNetworkInformation = CloudAdaptiveNetwork + "/host-network-information"
 	// NetworkingRule is a constant variable of "/registry/cloud-adaptive-network/networking-rule" key
-	NetworkingRule = "/registry/cloud-adaptive-network/networking-rule"
+	NetworkingRule = CloudAdaptiveNetwork + "/networking-rule"
+	// ControlCommand is a constant variable of "/registry/cloud-adaptive-network/control-command" key
+	ControlCommand = CloudAdaptiveNetwork + "/control-command"
 	// Status is a constant variable of "/registry/cloud-adaptive-network/status" key
-	Status = "/registry/cloud-adaptive-network/status"
+	Status = CloudAdaptiveNetwork + "/status"
 	// StatusTestSpecification is a constant variable of "/registry/cloud-adaptive-network/status/test-specification" key
 	StatusTestSpecification = Status + "/test-specification"
 	// StatusInformation is a constant variable of "/registry/cloud-adaptive-network/status/information" key

--- a/poc-cb-net/internal/network-helper/network-helper.go
+++ b/poc-cb-net/internal/network-helper/network-helper.go
@@ -14,7 +14,7 @@ var ipnet10, ipnet172, ipnet192 *net.IPNet
 
 func init() {
 	// Initialize private networks
-	for _, CIDRBlock := range []string{
+	for _, IPNetwork := range []string{
 		"127.0.0.0/8",    // IPv4 loopback
 		"10.0.0.0/8",     // RFC1918
 		"172.16.0.0/12",  // RFC1918
@@ -24,9 +24,9 @@ func init() {
 		"fe80::/10",      // IPv6 link-local
 		"fc00::/7",       // IPv6 unique local addr
 	} {
-		_, privateNetwork, err := net.ParseCIDR(CIDRBlock)
+		_, privateNetwork, err := net.ParseCIDR(IPNetwork)
 		if err != nil {
-			panic(fmt.Errorf("parse error on %q: %v", CIDRBlock, err))
+			panic(fmt.Errorf("parse error on %q: %v", IPNetwork, err))
 		}
 		privateNetworks = append(privateNetworks, privateNetwork)
 	}
@@ -110,7 +110,7 @@ func getDescendingOrderedKeysOfMap(m map[int]bool) []int {
 	return sortedKeys
 }
 
-// GetAvailableIPv4PrivateAddressSpaces represents a function to check and return available CIDR blocks
+// GetAvailableIPv4PrivateAddressSpaces represents a function to check and return the available IPv4 private address spaces
 func GetAvailableIPv4PrivateAddressSpaces(strIPNets []string) *AvailableIPv4PrivateAddressSpaces {
 	// CBLogger.Debug("Start.........")
 

--- a/poc-cb-net/web/public/index.html
+++ b/poc-cb-net/web/public/index.html
@@ -170,7 +170,7 @@
                         </tr>
                         <tr>
                             <td class="align-center">Network (IPv4 CIDR block)</td>
-                            <td class="align-center"><input type="text" id="cladnet-cidr-block"/><span>(IP address / Subnet mask will be converted and provided)</span>
+                            <td class="align-center"><input type="text" id="cladnet-ipv4-network"/><span>(IP address / Subnet mask will be converted and provided)</span>
                             </td>
                         </tr>
                         <tr>
@@ -259,18 +259,18 @@
 
         // Get the network (IPv4 CIDR block) and description to create CLADNet
         let elemCLADNetName = document.getElementById("cladnet-name");
-        let elemCLADNetCIDRBlock = document.getElementById("cladnet-cidr-block");
+        let elemCLADNetIPv4Network = document.getElementById("cladnet-ipv4-network");
         let elemCLADNetDescription = document.getElementById("cladnet-description");
         
         console.log("CLADNetName:" + elemCLADNetName.value);
-        console.log("CLADNetCIDRBlock:" + elemCLADNetCIDRBlock.value);
+        console.log("CLADNetIPv4Network:" + elemCLADNetIPv4Network.value);
         console.log("CLADNetDescription:" + elemCLADNetDescription.value);
 
         // Build JSON data
         // Example:
         // {
         //     "CLADNetID":"cladnet1",
-        //     "CIDRBlock":"xxx.xxx.xxx.xxx/xx",
+        //     "IPv4Network":"xxx.xxx.xxx.xxx/xx",
         //     "gatewayIP": "xxx.xxx.xxx.1",
         //     "description": "xxxxx"
         // }
@@ -278,7 +278,7 @@
         let Spec = JSON.stringify({
             id: "",
             name: elemCLADNetName.value,
-            ipv4AddressSpace: elemCLADNetCIDRBlock.value,
+            ipv4AddressSpace: elemCLADNetIPv4Network.value,
             description: elemCLADNetDescription.value
         });
 
@@ -367,11 +367,11 @@
                 console.log(rule);
 
                 // Data sample
-                // data = "{\"hostID\":[\"2\"],\"hostIPCIDRBlock\":[\"192.168.10.2/23\"],\"hostIPAddress\":[\"192.168.10.2\"],\"PublicIP\":[\"xxx.xxx.xxx.xxx\"]}";
+                // data = "{\"hostID\":[\"2\"],\"hostIPv4Network\":[\"192.168.10.2/23\"],\"hostIPAddress\":[\"192.168.10.2\"],\"PublicIP\":[\"xxx.xxx.xxx.xxx\"]}";
                 // {
                 //     "CLADNetID":"cladnet1",
                 //     "hostID": ["2", "5"],
-                //     "hostIPCIDRBlock": ["xxx.xxx.xxx.2/yy", "xxx.xxx.xxx.3/yy"],
+                //     "hostIPv4Network": ["xxx.xxx.xxx.2/yy", "xxx.xxx.xxx.3/yy"],
                 //     "hostIPAddress": ["xxx.xxx.xxx.2", "xxx.xxx.xxx.3"],
                 //     "publicIPAddress": ["aaa.aaa.aaa.aaa", "bbb.bbb.bbb.bbb"]
                 // };
@@ -390,11 +390,11 @@
                 console.log(networkStatus);
 
                 // Data sample
-                // data = "{\"hostID\":[\"2\"],\"hostIPCIDRBlock\":[\"192.168.10.2/23\"],\"hostIPAddress\":[\"192.168.10.2\"],\"PublicIP\":[\"xxx.xxx.xxx.xxx\"]}";
+                // data = "{\"hostID\":[\"2\"],\"hostIPv4Network\":[\"192.168.10.2/23\"],\"hostIPAddress\":[\"192.168.10.2\"],\"PublicIP\":[\"xxx.xxx.xxx.xxx\"]}";
                 // {
                 //     "CLADNetID":"cladnet1",
                 //     "hostID": ["2", "5"],
-                //     "hostIPCIDRBlock": ["xxx.xxx.xxx.2/yy", "xxx.xxx.xxx.3/yy"],
+                //     "hostIPv4Network": ["xxx.xxx.xxx.2/yy", "xxx.xxx.xxx.3/yy"],
                 //     "hostIPAddress": ["xxx.xxx.xxx.2", "xxx.xxx.xxx.3"],
                 //     "publicIPAddress": ["aaa.aaa.aaa.aaa", "bbb.bbb.bbb.bbb"]
                 // };
@@ -443,14 +443,14 @@
             let elemRule = document.getElementById(json.hostID[i]);
             if (elemRule) {
                 elemRule.children[0].innerText = json.hostID[i];
-                elemRule.children[1].innerText = json.hostIPCIDRBlock[i];
+                elemRule.children[1].innerText = json.hostIPv4Network[i];
                 elemRule.children[2].innerText = json.hostIPAddress[i];
                 elemRule.children[3].innerText = json.publicIPAddress[i];
             } else {
                 let elemNetworkingRuleData = document.getElementById("net-rule-data");
                 elemNetworkingRuleData.innerHTML += ('<tr id="' + json.hostID[i] + '" class="' + json.CLADNetID + '">' +
                     '<td class="align-center">' + json.hostID[i] + '</td>' +
-                    '<td class="align-center">' + json.hostIPCIDRBlock[i] + '</td>' +
+                    '<td class="align-center">' + json.hostIPv4Network[i] + '</td>' +
                     '<td class="align-center">' + json.hostIPAddress[i] + '</td>' +
                     '<td class="align-center">' + json.publicIPAddress[i] + '</td>' +
                     '</tr>');
@@ -479,7 +479,7 @@
                 for (let j = 0; j < existingCLADNet.data.length; j++) {
                     if (json.hostID[i] == existingCLADNet.data[j].name) {
                         includedHost = true;
-                        existingCLADNet.data[j].network = json.hostIPCIDRBlock[i] + " - " + json.publicIPAddress[i];
+                        existingCLADNet.data[j].network = json.hostIPv4Network[i] + " - " + json.publicIPAddress[i];
                         break;
                     }
                 }
@@ -487,7 +487,7 @@
                     existingCLADNet.data.push({
                         name: json.hostID[i],
                         value: Math.floor(Math.random() * 30 + 1),
-                        network: json.hostIPCIDRBlock[i] + " - " + json.publicIPAddress[i]
+                        network: json.hostIPv4Network[i] + " - " + json.publicIPAddress[i]
                     });
                 }
             }
@@ -502,7 +502,7 @@
                 obj.data.push({
                     name: json.hostID[i],
                     value: Math.floor(Math.random() * 30 + 1),
-                    network: json.hostIPCIDRBlock[i] + " - " + json.publicIPAddress[i]
+                    network: json.hostIPv4Network[i] + " - " + json.publicIPAddress[i]
                 });
             }
             chartDataFrame.series.push(obj);


### PR DESCRIPTION
- Re-structure the cb-network agent to control it remotely
- Change network-related naming convention
- Newly create command package to use a command in the same manner and also to add new command easily