### PR TITLE
Control the cb-network agent from the remote

### DIFF
--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -89,7 +89,7 @@ func watchControlCommand(etcdClient *clientv3.Client, wg *sync.WaitGroup) {
 		for _, event := range watchResponse.Events {
 			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 
-			controlCommand, controlCommandOption := cmd.ParseMessageBody(string(event.Kv.Value))
+			controlCommand, controlCommandOption := cmd.ParseCommandMessage(string(event.Kv.Value))
 
 			handleCommand(controlCommand, controlCommandOption, etcdClient)
 		}
@@ -102,6 +102,7 @@ func handleCommand(command string, commandOption string, etcdClient *clientv3.Cl
 	CBLogger.Debug("Start.........")
 
 	CBLogger.Debugf("Command: %+v", command)
+	CBLogger.Tracef("Command: %+v", commandOption)
 	switch command {
 	case "suspend":
 		// TBD

--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -102,10 +102,10 @@ func handleCommand(command string, commandOption string, etcdClient *clientv3.Cl
 	CBLogger.Debug("Start.........")
 
 	CBLogger.Debugf("Command: %+v", command)
-	CBLogger.Tracef("Command: %+v", commandOption)
+	CBLogger.Tracef("CommandOption: %+v", commandOption)
 	switch command {
 	case "suspend":
-		// TBD
+		CBNet.Shutdown()
 
 	case "resume":
 

--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -68,20 +68,21 @@ func init() {
 // CBNetwork represents a network for the multi-cloud
 type CBNetwork struct {
 	// Variables for the cb-network
-	NetworkingRules model.NetworkingRule // Networking rule for Interface and tunneling
+	NetworkingRules model.NetworkingRule // Networking rule for a network interface and tunneling
 	ID              string               // ID for a cloud adaptive network
 
 	// Variables for the cb-network controller
+	// TBD
 
 	// Variables for the cb-network agents
 	HostID                  string           // HostID in a cloud adaptive network
 	HostPublicIP            string           // Inquired public IP of VM/Host
 	HostPrivateIPv4Networks []string         // Inquired private IPv4 networks of VM/Host (e.g. ["192.168.10.4/24", ...])
 	Interface               *water.Interface // Assigned cbnet0 IP from the controller
-	name                    string           // InterfaceName of Interface, e.g., cbnet0
+	name                    string           // Name of a network interface, e.g., cbnet0
 	port                    int              // Port used for tunneling
-	isRunning               bool             // Status if a cloud adaptive network is running
-	notificationChannel     chan bool        // Notification channel to start tunneling
+	isInterfaceConfigured   bool             // Status if a network interface is configured or not
+	notificationChannel     chan bool        // Channel to notify the status of a network interface
 
 	//listenConnection  *net.UDPConn                // Connection for encapsulation and decapsulation
 	//NetworkInterfaces []model.NetworkInterface // Deprecated
@@ -92,10 +93,10 @@ func New(name string, port int) *CBNetwork {
 	CBLogger.Debug("Start.........")
 
 	temp := &CBNetwork{
-		name:                name,
-		port:                port,
-		isRunning:           false,
-		notificationChannel: make(chan bool),
+		name:                  name,
+		port:                  port,
+		isInterfaceConfigured: false,
+		notificationChannel:   make(chan bool),
 	}
 	temp.UpdateHostNetworkInformation()
 
@@ -126,7 +127,7 @@ func (cbnetwork *CBNetwork) inquireVMPublicIP() {
 	for _, url := range urls {
 
 		// Try to inquire public IP address
-		CBLogger.Info("Try to inuire public IP address")
+		CBLogger.Debug("Try to inuire public IP address")
 		CBLogger.Tracef("by %s", url)
 
 		resp, err := http.Get(url)
@@ -178,7 +179,7 @@ func (cbnetwork *CBNetwork) getPrivateIPv4Networks() {
 	// Recursively get network interface information
 	for _, iface := range ifaces {
 		// Print a network interface name
-		CBLogger.Trace("Interface name:", iface.Name)
+		CBLogger.Trace("Interface name: ", iface.Name)
 
 		// Declare a NetworkInterface variable
 		var networkInterface model.NetworkInterface
@@ -220,9 +221,9 @@ func (cbnetwork *CBNetwork) getPrivateIPv4Networks() {
 			if isPrivateIP {
 				if version == IPv4 { // Is IPv4 ?
 					tempIPNetworks = append(tempIPNetworks, networkIDStr)
-					CBLogger.Tracef("True v4 %s, %s", ipAddrStr, networkIDStr)
+					CBLogger.Tracef("IPv4: %s, %s", ipAddrStr, networkIDStr)
 				} else if version == IPv6 { // Is IPv6 ?
-					CBLogger.Tracef("True v6 %s, %s", ipAddrStr, networkIDStr)
+					CBLogger.Tracef("IPv6: %s, %s", ipAddrStr, networkIDStr)
 				} else { // Unknown version
 					CBLogger.Trace("!!! Unknown version !!!")
 				}
@@ -248,21 +249,6 @@ func (cbnetwork CBNetwork) GetHostNetworkInformation() model.HostNetworkInformat
 	return temp
 }
 
-//func (cbnetwork CBNetwork) IsSameNetworkInformation(net1 model.HostNetworkInformation, net2 model.HostNetworkInformation) bool {
-//
-//	isSame := false
-//	if net1.PublicIP == net2.PublicIP {
-//		isSame = true
-//		for i, privateNetwork := range net1.PrivateIPv4Networks {
-//			if privateNetwork != net2.PrivateIPv4Networks[i] {
-//				isSame = false
-//				break
-//			}
-//		}
-//	}
-//	return isSame
-//}
-
 // SetNetworkingRules represents a function to set a networking rule
 func (cbnetwork *CBNetwork) SetNetworkingRules(rules model.NetworkingRule) {
 	CBLogger.Debug("Start.........")
@@ -276,12 +262,42 @@ func (cbnetwork *CBNetwork) SetNetworkingRules(rules model.NetworkingRule) {
 	CBLogger.Debug("End.........")
 }
 
-func (cbnetwork *CBNetwork) initCBNet() (int, error) {
+// DecodeAndSetNetworkingRule represents a function to decode binary of networking rule and set it.
+func (cbnetwork *CBNetwork) DecodeAndSetNetworkingRule(value []byte) {
+	CBLogger.Debug("Start.........")
+
+	var networkingRule model.NetworkingRule
+
+	err := json.Unmarshal(value, &networkingRule)
+	if err != nil {
+		CBLogger.Error(err)
+	}
+
+	prettyJSON, _ := json.MarshalIndent(networkingRule, "", "\t")
+	CBLogger.Trace("Pretty JSON")
+	CBLogger.Trace(string(prettyJSON))
+
+	if networkingRule.Contain(cbnetwork.HostID) {
+		cbnetwork.SetNetworkingRules(networkingRule)
+		if !cbnetwork.isInterfaceConfigured {
+			err := cbnetwork.configureCBNetworkInterface()
+			if err != nil {
+				CBLogger.Error(err)
+				return
+			}
+			cbnetwork.isInterfaceConfigured = true
+			cbnetwork.notificationChannel <- cbnetwork.isInterfaceConfigured
+		}
+	}
+	CBLogger.Debug("End.........")
+}
+
+func (cbnetwork *CBNetwork) configureCBNetworkInterface() error {
 	CBLogger.Debug("Start.........")
 
 	idx := cbnetwork.NetworkingRules.GetIndexOfPublicIP(cbnetwork.HostPublicIP)
 	if idx < 0 || idx >= len(cbnetwork.NetworkingRules.HostID) {
-		return -1, errors.New("index out of range")
+		return errors.New("index out of range")
 	}
 	localNetwork := cbnetwork.NetworkingRules.HostIPv4Network[idx]
 
@@ -309,7 +325,7 @@ func (cbnetwork *CBNetwork) initCBNet() (int, error) {
 	cbnetwork.runIP("link", "set", "dev", cbnetwork.Interface.Name(), "up")
 
 	CBLogger.Debug("End.........")
-	return 0, nil
+	return nil
 }
 
 func (cbnetwork *CBNetwork) runIP(args ...string) {
@@ -329,42 +345,22 @@ func (cbnetwork *CBNetwork) runIP(args ...string) {
 	CBLogger.Debug("End.........")
 }
 
-// IsRunning represents a status of CBNetwork
-func (cbnetwork CBNetwork) IsRunning() bool {
+// Startup represents a function to start the cloud-barista network.
+func (cbnetwork *CBNetwork) Startup() {
 	CBLogger.Debug("Start.........")
 
-	CBLogger.Debug("IsRunning? ", cbnetwork.isRunning)
-
-	CBLogger.Debug("End.........")
-	return cbnetwork.isRunning
-}
-
-// StartCBNetworking represents a function to start networking by networking rules
-func (cbnetwork *CBNetwork) StartCBNetworking() (int, error) {
-	CBLogger.Debug("Start.........")
-
-	CBLogger.Info("Run CBNetworking between VMs")
-	ret, err := cbnetwork.initCBNet()
-	if err != nil {
-		return ret, err
-	}
-	cbnetwork.isRunning = true
-	cbnetwork.notificationChannel <- cbnetwork.isRunning
-
-	CBLogger.Debug("End.........")
-	return 0, nil
-}
-
-// RunTunneling represents a function to be performing tunneling between hosts (e.g., VMs).
-func (cbnetwork *CBNetwork) RunTunneling() {
-	// defer wg.Done()
-	CBLogger.Debug("Start.........")
-
-	CBLogger.Debug("Blocked till Networking Rule setup")
+	CBLogger.Debug("Blocked till the networking rule setup")
 	<-cbnetwork.notificationChannel
 
-	CBLogger.Debug("Start decapsulation")
-	// Decapsulation
+	cbnetwork.runTunneling()
+
+	CBLogger.Debug("End.........")
+}
+
+// runTunneling represents a function to be performing tunneling between hosts (e.g., VMs).
+func (cbnetwork *CBNetwork) runTunneling() {
+
+	CBLogger.Debug("Start.........")
 
 	// Listen to local socket
 	// Create network address to listen
@@ -387,7 +383,9 @@ func (cbnetwork *CBNetwork) RunTunneling() {
 		}
 	}()
 
+	// Decapsulation
 	go func() {
+		CBLogger.Debug("Start decapsulation")
 		buf := make([]byte, BUFFERSIZE)
 		for {
 			// ReadFromUDP acts like ReadFrom but returns a UDPAddr.
@@ -414,8 +412,8 @@ func (cbnetwork *CBNetwork) RunTunneling() {
 		}
 	}()
 
-	CBLogger.Debug("Start encapsulation")
 	// Encapsulation
+	CBLogger.Debug("Start encapsulation")
 	packet := make([]byte, BUFFERSIZE)
 	for {
 		// Read packet from HostIPv4Network interface "cbnet0"
@@ -450,31 +448,20 @@ func (cbnetwork *CBNetwork) RunTunneling() {
 			CBLogger.Errorf("Error(%d len): %s", nWriteToUDP, errWriteToUDP)
 		}
 	}
+
+	CBLogger.Debug("End.........")
 }
 
-// DecodeAndSetNetworkingRule represents a function to decode binary of networking rule and set it.
-func (cbnetwork *CBNetwork) DecodeAndSetNetworkingRule(value []byte) {
+// Shutdown represents a function to stop the cloud-barista network.
+func (cbnetwork *CBNetwork) Shutdown() {
 	CBLogger.Debug("Start.........")
 
-	var networkingRule model.NetworkingRule
+	// Stop tunneling routines
+	// xxx
 
-	err := json.Unmarshal(value, &networkingRule)
-	if err != nil {
-		CBLogger.Error(err)
-	}
+	// Set the interface down
+	cbnetwork.runIP("link", "set", "dev", cbnetwork.Interface.Name(), "down")
+	cbnetwork.isInterfaceConfigured = false
 
-	prettyJSON, _ := json.MarshalIndent(networkingRule, "", "\t")
-	CBLogger.Trace("Pretty JSON")
-	CBLogger.Trace(string(prettyJSON))
-
-	if networkingRule.Contain(cbnetwork.HostID) {
-		cbnetwork.SetNetworkingRules(networkingRule)
-		if !cbnetwork.IsRunning() {
-			_, err := cbnetwork.StartCBNetworking()
-			if err != nil {
-				CBLogger.Error(err)
-			}
-		}
-	}
 	CBLogger.Debug("End.........")
 }

--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -449,7 +449,8 @@ func (cbnetwork *CBNetwork) runTunneling() {
 		}
 	}
 
-	CBLogger.Debug("End.........")
+	// Unreachable
+	// CBLogger.Debug("End.........")
 }
 
 // Shutdown represents a function to stop the cloud-barista network.
@@ -457,7 +458,7 @@ func (cbnetwork *CBNetwork) Shutdown() {
 	CBLogger.Debug("Start.........")
 
 	// Stop tunneling routines
-	// xxx
+	// TBD
 
 	// Set the interface down
 	cbnetwork.runIP("link", "set", "dev", cbnetwork.Interface.Name(), "down")

--- a/poc-cb-net/internal/command/command.go
+++ b/poc-cb-net/internal/command/command.go
@@ -7,18 +7,23 @@ import (
 )
 
 const (
-	Resume            = "resume"
-	Suspend           = "suspend"
+	// Resume is a constant variable for command "resume"
+	Resume = "resume"
+	// Suspend is a constant variable for command "suspend"
+	Suspend = "suspend"
+	// CheckConnectivity is a constant variable for command "check-connectivity"
 	CheckConnectivity = "check-connectivity"
 )
 
 var placeHolder = `{"controlCommand": "%s", "controlCommandOption": "%s"}`
 
-func BuildMessageBody(controlCommand string, controlCommandOption string) string {
+// BuildCommandMessage represents a function to build a message with a command and its option.
+func BuildCommandMessage(controlCommand string, controlCommandOption string) string {
 	return fmt.Sprintf(placeHolder, controlCommand, controlCommandOption)
 }
 
-func ParseMessageBody(message string) (string, string) {
+// ParseCommandMessage represents a function to parse a command and its option from a message.
+func ParseCommandMessage(message string) (string, string) {
 	cmd := gjson.Get(message, "controlCommand").String()
 	cmdOption := gjson.Get(message, "controlCommandOption").String()
 	return cmd, cmdOption

--- a/poc-cb-net/web/public/index.html
+++ b/poc-cb-net/web/public/index.html
@@ -154,6 +154,30 @@
     </div>
 </section>
 
+<!-- Table -->
+<section id="cladnet-remote-control" class="one">
+    <div class="inner">
+        <header>
+            <h4 class="align-center">Remote-control of CLADNet</h2>
+        </header>
+        <div>
+            <div>
+                <div>
+                    <span>CLADNet: </span>
+                    <div class="select-wrapper">
+                        <select id="cladnet-id-for-remote-control" class="cladnet-id-dropdown-elem">
+                            <option value="" selected disabled hidden>Nothing to choose</option>
+                        </select>
+                    </div>                    
+                </div>
+                <br/>
+                <button type="button" onclick="resumeCLADNet()">Resume</button>
+                <button type="button" onclick="suspendCLADNet()">Suspend</button>
+            </div>
+        </div>
+    </div>
+</section>
+
 <!-- The creation interface of cloud adaptive network -->
 <section id="cladnet-creation" class="one">
     <div class="inner">
@@ -197,7 +221,7 @@
                 <div>
                     <span>CLADNet: </span>
                     <div class="select-wrapper">
-                        <select id="cladnet-id">
+                        <select id="cladnet-id" class="cladnet-id-dropdown-elem">
                             <option value="" selected disabled hidden>Nothing to choose</option>
                         </select>
                     </div>
@@ -253,6 +277,55 @@
 
         // Send those to the AdminWeb server
         ws.send(dataframeStr);
+    }
+
+    function resumeCLADNet(){
+        let cladnetID = document.getElementById('cladnet-id-for-remote-control').value;
+
+        console.log("CLADNetID:" + cladnetID);
+        
+        // Build JSON data
+        // Example:
+        // {
+        //      "CLADNetID": "xxx",
+        //      "commandMessage": {
+        //          "controlCommand": "xxx",
+        //          "controlCommandOption": "xxx"
+        //      }
+        // }
+
+        let message = JSON.stringify({
+            CLADNetID: cladnetID,
+            controlCommand: "resume",
+            controlCommandOption: ""
+        });
+
+        sendDataframe("control-command", message);
+    }
+
+    function suspendCLADNet(){
+        let cladnetID = document.getElementById('cladnet-id-for-remote-control').value;        
+
+        console.log("CLADNetID:" + cladnetID);
+        
+        // Build JSON data
+        // Example:
+        // {
+        //      "CLADNetID": "xxx",
+        //      "commandMessage": {
+        //          "controlCommand": "xxx",
+        //          "controlCommandOption": "xxx"
+        //      }
+        // }
+
+        let message = JSON.stringify({
+            CLADNetID: cladnetID,
+            controlCommand: "suspend",
+            controlCommandOption: ""
+        });
+
+        sendDataframe("control-command", message);
+        
     }
 
     function createCLADNet() {
@@ -426,15 +499,15 @@
     }
 
     function updateCLADNetDropdownList(list) {
-        let dropdownElemOfCLADNetID = document.getElementById("cladnet-id");
+        let elems = document.getElementsByClassName("cladnet-id-dropdown-elem");
 
-        dropdownElemOfCLADNetID.innerHTML = '';
-        dropdownElemOfCLADNetID.innerHTML += '<option value="" selected disabled hidden>Choose here</option>';
+        for (var i=0; i<elems.length; i++) {
+            elems[i].innerHTML = '';
+            elems[i].innerHTML += '<option value="" selected disabled hidden>Choose here</option>';
 
-        //<option value="" selected disabled hidden>Choose here</option>
-
-        for (let i = 0; i < list.length; i++) {
-            dropdownElemOfCLADNetID.innerHTML += '<option value="' + list[i].id + '">' + list[i].id + '</option>';
+            for (let j = 0; j < list.length; j++) {
+                elems[i].innerHTML += '<option value="' + list[j].id + '">' + list[j].id + '</option>';
+            }
         }
     }
 


### PR DESCRIPTION
- Include the status test in the control command as the `check-connectivity`
- Provide `resume` and `suspend` commands to control cb-network agents remotely
- Improve the overall `cb-network` package for this