### PR TITLE
Fix abnormal networking rule sychronization

### DIFF
--- a/poc-cb-net/internal/cb-network/cb-network.go
+++ b/poc-cb-net/internal/cb-network/cb-network.go
@@ -304,6 +304,10 @@ func (cbnetwork *CBNetwork) UpdatePeer(value []byte) (isThisPeerInitialized bool
 			}
 			cbnetwork.isInterfaceConfigured = true
 			cbnetwork.notificationChannel <- cbnetwork.isInterfaceConfigured
+
+			// Wait until tunneling() is started
+			time.Sleep(1 * time.Second)
+
 			return true
 		}
 	}

--- a/poc-cb-net/internal/etcd-key/etcd-key.go
+++ b/poc-cb-net/internal/etcd-key/etcd-key.go
@@ -27,4 +27,7 @@ const (
 
 	// Secret is a constant variable of "/registry/cloud-adaptive-network/secret" key
 	Secret = CloudAdaptiveNetwork + "/secret"
+
+	// DistributedLock is a constant variable of "/registry/cloud-adaptive-network/distributed-lock" key
+	DistributedLock = CloudAdaptiveNetwork + "/distributed-lock"
 )

--- a/poc-cb-net/scripts/1.deploy-cb-network-agent.sh
+++ b/poc-cb-net/scripts/1.deploy-cb-network-agent.sh
@@ -85,7 +85,7 @@ cblog:
   loopcheck: true # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
 
   ## trace | debug | info | warn | error
-  loglevel: debug # If loopcheck is true, You can set this online.
+  loglevel: trace # If loopcheck is true, You can set this online.
 
   ## true | false
   logfile: false

--- a/poc-cb-net/scripts/2.re-deploy-cb-network-agent.sh
+++ b/poc-cb-net/scripts/2.re-deploy-cb-network-agent.sh
@@ -92,7 +92,7 @@ cblog:
   loopcheck: true # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
 
   ## trace | debug | info | warn | error
-  loglevel: debug # If loopcheck is true, You can set this online.
+  loglevel: trace # If loopcheck is true, You can set this online.
 
   ## true | false
   logfile: false


### PR DESCRIPTION
- Synchonize the other hosts' networking rule with distributed lock
- Put host network information by each host
- Allocate or update the network rule for a host with distributed lock
- Add new etcd key for distributed-lock