### PR TITLE
Improve the cb-network agent state tracking

### DIFF
--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -210,7 +210,7 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 							PrivateIPv4Network: hostIPv4Network,
 							PrivateIPv4Address: hostIPAddress,
 							PublicIPv4Address:  hostNetworkInformation.PublicIP,
-							State:              model.Suspended,
+							State:              model.Configuring,
 						}
 
 					} else { // Update the host's configuration

--- a/poc-cb-net/internal/cb-network/model/peer.go
+++ b/poc-cb-net/internal/cb-network/model/peer.go
@@ -4,11 +4,14 @@ const (
 	// Running is const for the running state
 	Running = "running"
 
-	// Suspending is const for the suspended state
+	// Suspending is const for the suspending state
 	Suspending = "suspending"
 
 	// Suspended is const for the suspended state
 	Suspended = "suspended"
+
+	// Configuring is const for the configuring state
+	Configuring = "configuring"
 )
 
 // Peer represents a host's rule of the cloud adaptive network.


### PR DESCRIPTION
- Add `configuring` state
- Add `syscall.SIGHUP` and `syscall.SIGABRT` for graceful shutdown
- Update graceful shutdown processes