### PR TITLE
Reduce complexity to update networking rule

### DIFF
--- a/poc-cb-net/cmd/admin-web/admin-web.go
+++ b/poc-cb-net/cmd/admin-web/admin-web.go
@@ -305,7 +305,7 @@ func handleControlCLADNet(etcdClient *clientv3.Client, responseText string) {
 
 func getExistingNetworkInfo(etcdClient *clientv3.Client) error {
 
-	// Get the networking rule
+	// Get all peers
 	CBLogger.Debugf("Get - %v", etcdkey.Peer)
 	resp, etcdErr := etcdClient.Get(context.Background(), etcdkey.Peer, clientv3.WithPrefix())
 	CBLogger.Tracef("etcdResp: %v", resp)

--- a/poc-cb-net/cmd/admin-web/admin-web.go
+++ b/poc-cb-net/cmd/admin-web/admin-web.go
@@ -507,7 +507,7 @@ func watchPeer(wg *sync.WaitGroup, etcdClient *clientv3.Client) {
 			}
 		}
 	}
-	CBLogger.Debugf("End to watch \"%v\"", etcdkey.NetworkingRule)
+	CBLogger.Debugf("End to watch \"%v\"", etcdkey.Peer)
 }
 
 func watchCLADNetSpecification(wg *sync.WaitGroup, etcdClient *clientv3.Client) {

--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -340,92 +340,92 @@ func pingTest(outVal *model.InterHostNetworkStatus, wg *sync.WaitGroup, trialCou
 	CBLogger.Debug("End.........")
 }
 
-func watchThisPeer(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
-	CBLogger.Debug("Start.........")
+// func watchThisPeer(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
+// 	CBLogger.Debug("Start.........")
 
-	defer wg.Done()
+// 	defer wg.Done()
 
-	// Watch "/registry/cloud-adaptive-network/peer/{cladnet-id}/{host-id}" with version
-	keyThisPeer := fmt.Sprint(etcdkey.Peer + "/" + CBNet.CLADNetID + "/" + CBNet.HostID)
-	CBLogger.Tracef("Watch \"%v\"", keyThisPeer)
-	watchChan1 := etcdClient.Watch(ctx, keyThisPeer, clientv3.WithPrefix())
-	for watchResponse := range watchChan1 {
-		for _, event := range watchResponse.Events {
-			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+// 	// Watch "/registry/cloud-adaptive-network/peer/{cladnet-id}/{host-id}" with version
+// 	keyThisPeer := fmt.Sprint(etcdkey.Peer + "/" + CBNet.CLADNetID + "/" + CBNet.HostID)
+// 	CBLogger.Tracef("Watch \"%v\"", keyThisPeer)
+// 	watchChan1 := etcdClient.Watch(ctx, keyThisPeer, clientv3.WithPrefix())
+// 	for watchResponse := range watchChan1 {
+// 		for _, event := range watchResponse.Events {
+// 			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 
-			key := string(event.Kv.Key)
+// 			key := string(event.Kv.Key)
 
-			var peer model.Peer
-			err := json.Unmarshal(event.Kv.Value, &peer)
-			if err != nil {
-				CBLogger.Error(err)
-			}
+// 			var peer model.Peer
+// 			err := json.Unmarshal(event.Kv.Value, &peer)
+// 			if err != nil {
+// 				CBLogger.Error(err)
+// 			}
 
-			CBNet.ThisPeer = peer
+// 			CBNet.ThisPeer = peer
 
-			if peer.State == netstate.Configuring {
-				err := CBNet.ConfigureCBNetworkInterface()
-				if err != nil {
-					CBLogger.Error(err)
+// 			if peer.State == netstate.Configuring {
+// 				err := CBNet.ConfigureCBNetworkInterface()
+// 				if err != nil {
+// 					CBLogger.Error(err)
 
-				} else {
-					peer.State = netstate.Tunneling
-					doc, _ := json.Marshal(peer)
+// 				} else {
+// 					peer.State = netstate.Tunneling
+// 					doc, _ := json.Marshal(peer)
 
-					CBLogger.Debugf("Put - \"%v\"", key)
-					if _, err := etcdClient.Put(context.TODO(), key, string(doc)); err != nil {
-						CBLogger.Error(err)
-					}
-				}
-			}
-		}
-	}
-	CBLogger.Debug("End.........")
-}
+// 					CBLogger.Debugf("Put - \"%v\"", key)
+// 					if _, err := etcdClient.Put(context.TODO(), key, string(doc)); err != nil {
+// 						CBLogger.Error(err)
+// 					}
+// 				}
+// 			}
+// 		}
+// 	}
+// 	CBLogger.Debug("End.........")
+// }
 
-func watchNetworkingRule(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
-	CBLogger.Debug("Start.........")
+// func watchNetworkingRule(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
+// 	CBLogger.Debug("Start.........")
 
-	defer wg.Done()
+// 	defer wg.Done()
 
-	// Watch "/registry/cloud-adaptive-network/networking-rule/{cladnet-id}/{host-id}"
-	keyNetworkingRuleOfPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + CBNet.CLADNetID + "/" + CBNet.HostID)
-	CBLogger.Tracef("Watch \"%v\"", keyNetworkingRuleOfPeer)
-	watchChan1 := etcdClient.Watch(ctx, keyNetworkingRuleOfPeer)
-	for watchResponse := range watchChan1 {
-		for _, event := range watchResponse.Events {
-			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+// 	// Watch "/registry/cloud-adaptive-network/networking-rule/{cladnet-id}/{host-id}"
+// 	keyNetworkingRuleOfPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + CBNet.CLADNetID + "/" + CBNet.HostID)
+// 	CBLogger.Tracef("Watch \"%v\"", keyNetworkingRuleOfPeer)
+// 	watchChan1 := etcdClient.Watch(ctx, keyNetworkingRuleOfPeer)
+// 	for watchResponse := range watchChan1 {
+// 		for _, event := range watchResponse.Events {
+// 			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 
-			// key := string(event.Kv.Key)
+// 			// key := string(event.Kv.Key)
 
-			var networkingRule model.NetworkingRule
-			err := json.Unmarshal(event.Kv.Value, &networkingRule)
-			if err != nil {
-				CBLogger.Error(err)
-			}
+// 			var networkingRule model.NetworkingRule
+// 			err := json.Unmarshal(event.Kv.Value, &networkingRule)
+// 			if err != nil {
+// 				CBLogger.Error(err)
+// 			}
 
-			// Update a host's configuration in the networking rule
-			CBNet.UpdateNetworkingRule(networkingRule)
+// 			// Update a host's configuration in the networking rule
+// 			CBNet.UpdateNetworkingRule(networkingRule)
 
-			// if peer.HostID == CBNet.HostID && peer.State == netstate.Configuring {
-			// 	err := CBNet.ConfigureCBNetworkInterface()
-			// 	if err != nil {
-			// 		CBLogger.Error(err)
+// 			// if peer.HostID == CBNet.HostID && peer.State == netstate.Configuring {
+// 			// 	err := CBNet.ConfigureCBNetworkInterface()
+// 			// 	if err != nil {
+// 			// 		CBLogger.Error(err)
 
-			// 	} else {
-			// 		peer.State = netstate.Tunneling
-			// 		doc, _ := json.Marshal(peer)
+// 			// 	} else {
+// 			// 		peer.State = netstate.Tunneling
+// 			// 		doc, _ := json.Marshal(peer)
 
-			// 		CBLogger.Debugf("Put - \"%v\"", key)
-			// 		if _, err := etcdClient.Put(context.TODO(), key, string(doc)); err != nil {
-			// 			CBLogger.Error(err)
-			// 		}
-			// 	}
-			// }
-		}
-	}
-	CBLogger.Debug("End.........")
-}
+// 			// 		CBLogger.Debugf("Put - \"%v\"", key)
+// 			// 		if _, err := etcdClient.Put(context.TODO(), key, string(doc)); err != nil {
+// 			// 			CBLogger.Error(err)
+// 			// 		}
+// 			// 	}
+// 			// }
+// 		}
+// 	}
+// 	CBLogger.Debug("End.........")
+// }
 
 func initializeAgent(etcdClient *clientv3.Client) {
 	CBLogger.Debug("Start.........")
@@ -623,61 +623,90 @@ func initializeSecret(etcdClient *clientv3.Client) {
 	CBLogger.Debug("End.........")
 }
 
-/////////////////////////////////////////////
-/////////////////////////////////////////////
-/////////////////////////////////////////////
-
-func watchPeer(wg *sync.WaitGroup, etcdClient *clientv3.Client, controllerID string) {
+// Watch all peers related to the same Cloud Adaptive Network
+func watchPeer(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
+	CBLogger.Debug("Start.........")
 	defer wg.Done()
-	// Watch "/registry/cloud-adaptive-network/host-network-information"
-	CBLogger.Debugf("Start to watch \"%v\"", etcdkey.Peer)
+
+	// Watch "/registry/cloud-adaptive-network/peer/{cladnet-id}"
+	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + CBNet.CLADNetID)
+	CBLogger.Tracef("Watch \"%v\"", keyPeersInCLADNet)
 
 	// Create a session to acquire a lock
 	session, _ := concurrency.NewSession(etcdClient)
 	defer session.Close()
 
-	watchChan2 := etcdClient.Watch(context.Background(), etcdkey.Peer, clientv3.WithPrefix())
-	for watchResponse := range watchChan2 {
+	watchChan := etcdClient.Watch(ctx, keyPeersInCLADNet, clientv3.WithPrefix())
+	for watchResponse := range watchChan {
 		for _, event := range watchResponse.Events {
 			switch event.Type {
 			case mvccpb.PUT:
-				CBLogger.Tracef("\n[cb-network controller (%s)]\nWatch - %s %q : %q",
-					controllerID, event.Type, event.Kv.Key, event.Kv.Value)
+				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+				key := string(event.Kv.Key)
 
-				// Try to acquire a workload by multiple cb-network controllers
-				isAcquired := tryToAcquireWorkload(etcdClient, controllerID, string(event.Kv.Key), watchResponse.Header.GetRevision())
-
-				// Proceed the following by a cb-network controller acquiring the workload
-				if isAcquired {
-					// Parse HostID and CLADNetID from the Key
-					slicedKeys := strings.Split(string(event.Kv.Key), "/")
-					// parsedHostID := slicedKeys[len(slicedKeys)-1]
-					// CBLogger.Tracef("ParsedHostId: %v", parsedHostID)
-					parsedCLADNetID := slicedKeys[len(slicedKeys)-2]
-					CBLogger.Tracef("ParsedCLADNetId: %v", parsedCLADNetID)
-
-					// Prepare lock
-					keyPrefix := fmt.Sprint(etcdkey.LockPeer + "/" + parsedCLADNetID)
-
-					lock := concurrency.NewMutex(session, keyPrefix)
-					ctx := context.TODO()
-
-					// Acquire lock (or wait to have it)
-					CBLogger.Debug("Acquire a lock")
-					if err := lock.Lock(ctx); err != nil {
-						CBLogger.Error(err)
-					}
-					CBLogger.Tracef("Acquired lock for '%s'", keyPrefix)
-
-					updateNetworkingRule(parsedCLADNetID, etcdClient, controllerID)
-
-					// Release lock
-					CBLogger.Debug("Release a lock")
-					if err := lock.Unlock(ctx); err != nil {
-						CBLogger.Error(err)
-					}
-					CBLogger.Tracef("Released lock for '%s'", keyPrefix)
+				var peer model.Peer
+				err := json.Unmarshal(event.Kv.Value, &peer)
+				if err != nil {
+					CBLogger.Error(err)
 				}
+				cladnetID := peer.CladnetID
+
+				// Prepare lock
+				keyPrefix := fmt.Sprint(etcdkey.LockPeer + "/" + cladnetID)
+
+				lock := concurrency.NewMutex(session, keyPrefix)
+				ctx := context.TODO()
+
+				// Acquire lock (or wait to have it)
+				CBLogger.Debug("Acquire a lock")
+				if err := lock.Lock(ctx); err != nil {
+					CBLogger.Error(err)
+				}
+				CBLogger.Tracef("Acquired lock for '%s'", keyPrefix)
+
+				if peer.HostID == CBNet.HostID { // for this peer
+
+					// Assgin peer
+					CBNet.ThisPeer = peer
+
+					// Configure a virtual network interface for Cloud Adaptive Network, if it is the configuring state
+					switch peer.State {
+					case netstate.Configuring:
+						err := CBNet.ConfigureCBNetworkInterface()
+						if err != nil {
+							CBLogger.Error(err)
+
+						} else {
+							// Initialize the networking rule for this peer
+							initializeNetworkingRule(peer, etcdClient)
+
+							// Udpate state of this peer
+							peer.State = netstate.Tunneling
+							doc, _ := json.Marshal(peer)
+
+							CBLogger.Debugf("Put - \"%v\"", key)
+							if _, err := etcdClient.Put(context.TODO(), key, string(doc)); err != nil {
+								CBLogger.Error(err)
+							}
+						}
+					case netstate.Tunneling:
+						// Initialize the networking rule for this peer
+						initializeNetworkingRule(peer, etcdClient)
+					}
+
+				} else { // for the other peers
+					// Keep updating networking rules if it is the tunneling state
+					if CBNet.ThisPeer.State == netstate.Tunneling {
+						updatePeerInNetworkingRule(peer, etcdClient)
+					}
+				}
+
+				// Release lock
+				CBLogger.Debug("Release a lock")
+				if err := lock.Unlock(ctx); err != nil {
+					CBLogger.Error(err)
+				}
+				CBLogger.Tracef("Released lock for '%s'", keyPrefix)
 
 			case mvccpb.DELETE: // The watched key has been deleted.
 				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
@@ -690,10 +719,11 @@ func watchPeer(wg *sync.WaitGroup, etcdClient *clientv3.Client, controllerID str
 	CBLogger.Debug("End.........")
 }
 
-func updateNetworkingRule(cladnetID string, etcdClient *clientv3.Client, controllerID string) {
+func initializeNetworkingRule(thisPeer model.Peer, etcdClient *clientv3.Client) {
 	CBLogger.Debug("Start.........")
-	// Get peers in a Cloud Adaptive Network
-	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
+
+	// Get all peers participated in the same Cloud Adaptive Network
+	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + thisPeer.CladnetID)
 	CBLogger.Tracef("Get - %v", keyPeersInCLADNet)
 
 	respPeers, etcdErr := etcdClient.Get(context.Background(), keyPeersInCLADNet, clientv3.WithPrefix())
@@ -706,7 +736,7 @@ func updateNetworkingRule(cladnetID string, etcdClient *clientv3.Client, control
 	if respPeers.Count >= 2 {
 
 		// Get a specification of a cloud adaptive network
-		keyCLADNetSpec := fmt.Sprint(etcdkey.CLADNetSpecification + "/" + cladnetID)
+		keyCLADNetSpec := fmt.Sprint(etcdkey.CLADNetSpecification + "/" + thisPeer.CladnetID)
 		CBLogger.Tracef("Get - %v", keyCLADNetSpec)
 
 		respCLADNetSpec, etcdErr := etcdClient.Get(context.Background(), keyCLADNetSpec)
@@ -721,86 +751,106 @@ func updateNetworkingRule(cladnetID string, etcdClient *clientv3.Client, control
 		}
 		CBLogger.Tracef("The CLADNet spec: %v", cladnetSpec)
 
-		var wg sync.WaitGroup
+		// Set the networking rule for this peer
+		var networkingRule model.NetworkingRule
+		networkingRule.CladnetID = thisPeer.CladnetID
 
-		// Set the networking rule for each peer
-		for _, kv := range respPeers.Kvs {
+		// Create networking rule table for each peer
+		for _, peerKv := range respPeers.Kvs {
 			// Value
-			sourcePeerBytes := kv.Value
-			var sourcePeer model.Peer
-			if err := json.Unmarshal(sourcePeerBytes, &sourcePeer); err != nil {
+			peerBytes := peerKv.Value
+			var peer model.Peer
+			if err := json.Unmarshal(peerBytes, &peer); err != nil {
 				CBLogger.Error(err)
 			}
-			CBLogger.Tracef("The source peer: %v", sourcePeer)
+			CBLogger.Tracef("A peer: %v", peer)
 
-			// Update networking rule for each peer in parallel
-			wg.Add(1)
-			CBLogger.Tracef("Update the networking rule of peer (ID: %+v, Name: %+v)", sourcePeer.HostID, sourcePeer.HostName)
-			go updateNetworkingRuleOfPeer(cladnetSpec.RuleType, sourcePeer, respPeers.Kvs, etcdClient, &wg)
+			if thisPeer.HostID != peer.HostID {
+				// Select destination IP
+				selectedIP, peerScope, err := cbnet.SelectDestinationByRuleType(cladnetSpec.RuleType, thisPeer, peer)
+				if err != nil {
+					CBLogger.Error(err)
+				}
+
+				CBLogger.Tracef("Selected IP: %+v", selectedIP)
+
+				networkingRule.UpdateRule(peer.HostID, peer.HostName, peer.IP, selectedIP, peerScope, peer.State)
+			}
 		}
-		wg.Wait()
-	}
-	CBLogger.Debug("End.........")
-}
 
-func updateNetworkingRuleOfPeer(ruleType string, sourcePeer model.Peer, peerKvs []*mvccpb.KeyValue, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
-	CBLogger.Trace("Start.........")
-	defer wg.Done()
+		// Assign the networking rule
+		CBNet.UpdateNetworkingRule(networkingRule)
 
-	var networkingRule model.NetworkingRule
+		// Transaction (compare-and-swap(CAS)) to put networking rule for a peer
+		keyNetworkingRuleOfThisPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + thisPeer.CladnetID + "/" + thisPeer.HostID)
+		CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
+		networkingRuleBytes, _ := json.Marshal(networkingRule)
+		networkingRuleString := string(networkingRuleBytes)
 
-	// Get the networking rule
-	keyNetworkingRuleOfPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + sourcePeer.CladnetID + "/" + sourcePeer.HostID)
-	CBLogger.Debugf("Get - %v", keyNetworkingRuleOfPeer)
+		// NOTICE: "!=" doesn't work..... It might be a temporal issue.
+		txnResp, err := etcdClient.Txn(context.TODO()).
+			If(clientv3.Compare(clientv3.Value(keyNetworkingRuleOfThisPeer), "=", networkingRuleString)).
+			Else(clientv3.OpPut(keyNetworkingRuleOfThisPeer, networkingRuleString)).
+			Commit()
 
-	respNetworkingRule, etcdErr := etcdClient.Get(context.Background(), keyNetworkingRuleOfPeer)
-	if etcdErr != nil {
-		CBLogger.Error(etcdErr)
-	}
-	CBLogger.Tracef("GetResponse: %v", respNetworkingRule)
-	CBLogger.Tracef("The number of peers (Count): %v", respNetworkingRule.Count)
-
-	if respNetworkingRule.Count > 0 {
-		err := json.Unmarshal(respNetworkingRule.Kvs[0].Value, &networkingRule)
 		if err != nil {
 			CBLogger.Error(err)
 		}
+
+		CBLogger.Tracef("TransactionResponse: %#v", txnResp)
+		CBLogger.Tracef("ResponseHeader: %#v", txnResp.Header)
 	}
 
-	networkingRule.CladnetID = sourcePeer.CladnetID
+	CBLogger.Debug("End.........")
+}
+
+func updatePeerInNetworkingRule(peer model.Peer, etcdClient *clientv3.Client) {
+	CBLogger.Trace("Start.........")
+
+	networkingRule := CBNet.NetworkingRule
+
+	// Get a specification of a cloud adaptive network
+	keyCLADNetSpec := fmt.Sprint(etcdkey.CLADNetSpecification + "/" + CBNet.CLADNetID)
+	CBLogger.Tracef("Get - %v", keyCLADNetSpec)
+
+	respCLADNetSpec, etcdErr := etcdClient.Get(context.Background(), keyCLADNetSpec)
+	if etcdErr != nil {
+		CBLogger.Error(etcdErr)
+	}
+	CBLogger.Tracef("GetResponse: %v", respCLADNetSpec)
+
+	var cladnetSpec model.CLADNetSpecification
+	if err := json.Unmarshal(respCLADNetSpec.Kvs[0].Value, &cladnetSpec); err != nil {
+		CBLogger.Error(err)
+	}
+	CBLogger.Tracef("The CLADNet spec: %v", cladnetSpec)
 
 	// Create networking rule table for each peer
-	for _, peerKv := range peerKvs {
-		// Value
-		peerBytes := peerKv.Value
-		var peer model.Peer
-		if err := json.Unmarshal(peerBytes, &peer); err != nil {
-			CBLogger.Error(err)
-		}
-		CBLogger.Tracef("A peer: %v", peer)
 
-		if sourcePeer.HostID != peer.HostID {
-			// Select destination IP
-			selectedIP, peerScope, err := cbnet.SelectDestinationByRuleType(ruleType, sourcePeer, peer)
-			if err != nil {
-				CBLogger.Error(err)
-			}
-
-			CBLogger.Tracef("Selected IP: %+v", selectedIP)
-
-			networkingRule.UpdateRule(peer.HostID, peer.HostName, peer.IP, selectedIP, peerScope, peer.State)
-		}
+	// Select destination IP
+	thisPeer := CBNet.ThisPeer
+	selectedIP, peerScope, err := cbnet.SelectDestinationByRuleType(cladnetSpec.RuleType, thisPeer, peer)
+	if err != nil {
+		CBLogger.Error(err)
 	}
 
+	CBLogger.Tracef("Selected IP: %+v", selectedIP)
+
+	networkingRule.UpdateRule(peer.HostID, peer.HostName, peer.IP, selectedIP, peerScope, peer.State)
+
+	// Assign the networking rule
+	CBNet.UpdateNetworkingRule(networkingRule)
+
 	// Transaction (compare-and-swap(CAS)) to put networking rule for a peer
-	CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfPeer)
+	keyNetworkingRuleOfThisPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + thisPeer.CladnetID + "/" + thisPeer.HostID)
+	CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
 	networkingRuleBytes, _ := json.Marshal(networkingRule)
 	networkingRuleString := string(networkingRuleBytes)
 
 	// NOTICE: "!=" doesn't work..... It might be a temporal issue.
 	txnResp, err := etcdClient.Txn(context.TODO()).
-		If(clientv3.Compare(clientv3.Value(keyNetworkingRuleOfPeer), "=", networkingRuleString)).
-		Else(clientv3.OpPut(keyNetworkingRuleOfPeer, networkingRuleString)).
+		If(clientv3.Compare(clientv3.Value(keyNetworkingRuleOfThisPeer), "=", networkingRuleString)).
+		Else(clientv3.OpPut(keyNetworkingRuleOfThisPeer, networkingRuleString)).
 		Commit()
 
 	if err != nil {
@@ -812,10 +862,6 @@ func updateNetworkingRuleOfPeer(ruleType string, sourcePeer model.Peer, peerKvs 
 
 	CBLogger.Trace("End.........")
 }
-
-/////////////////////////////////////////////
-/////////////////////////////////////////////
-/////////////////////////////////////////////
 
 func main() {
 	CBLogger.Debug("Start.........")
@@ -912,17 +958,21 @@ func main() {
 	// Wait until the goroutine is started
 	time.Sleep(200 * time.Millisecond)
 
+	// wg.Add(1)
+	// // Watch this peer
+	// go watchThisPeer(gracefulShutdownContext, etcdClient, &wg)
+	// // Wait until the goroutine is started
+	// time.Sleep(200 * time.Millisecond)
 	wg.Add(1)
-	// Watch this peer
-	go watchThisPeer(gracefulShutdownContext, etcdClient, &wg)
+	go watchPeer(gracefulShutdownContext, etcdClient, &wg)
 	// Wait until the goroutine is started
 	time.Sleep(200 * time.Millisecond)
 
-	wg.Add(1)
-	// Watch the networking rule to update dynamically
-	go watchNetworkingRule(gracefulShutdownContext, etcdClient, &wg)
-	// Wait until the goroutine is started
-	time.Sleep(200 * time.Millisecond)
+	// wg.Add(1)
+	// // Watch the networking rule to update dynamically
+	// go watchNetworkingRule(gracefulShutdownContext, etcdClient, &wg)
+	// // Wait until the goroutine is started
+	// time.Sleep(200 * time.Millisecond)
 
 	// Turn up the network interface (TUN) for Cloud Adaptive Network
 	handleCommand(cmdtype.Up, etcdClient)

--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -200,17 +200,17 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 					lock := concurrency.NewMutex(session, keyPrefix)
 					ctx := context.TODO()
 
-					// Acquire a lock to protect a networking rule
+					// Acquire a lock  (or wait to have it) to update peer
 					CBLogger.Debug("Acquire a lock")
 					if err := lock.Lock(ctx); err != nil {
 						CBLogger.Errorf("Could NOT acquire lock for '%v', error: %v", keyPrefix, err)
 					}
 					CBLogger.Tracef("Acquired lock for '%s'", keyPrefix)
 
-					// Create a key of host in the specific CLADNet's networking rule
+					// Create a key of peer
 					keyPeer := fmt.Sprint(etcdkey.Peer + "/" + parsedCLADNetID + "/" + parsedHostID)
 
-					// Get a host's networking rule
+					// Get a peer
 					CBLogger.Tracef("Key: %v", keyPeer)
 					respRule, respRuleErr := etcdClient.Get(context.TODO(), keyPeer)
 					if respRuleErr != nil {
@@ -244,7 +244,7 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 						CBLogger.Error(err)
 					}
 
-					// Release a lock to protect a networking rule
+					// Release a lock to update peer
 					CBLogger.Debug("Release a lock")
 					if err := lock.Unlock(ctx); err != nil {
 						CBLogger.Error(err)
@@ -394,12 +394,12 @@ func allocatePeer(cladnetID string, hostID string, hostName string, hostIPv4CIDR
 		CBLogger.Error(err)
 	}
 
-	// Create a key of host in the specific CLADNet's networking rule
-	keyPeer := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
+	// Create a key of peers in a Cloud Adaptive Network
+	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
 
-	// Get the count of networking rule
-	CBLogger.Tracef("Key: %v", keyPeer)
-	resp, respErr := etcdClient.Get(context.TODO(), keyPeer, clientv3.WithPrefix(), clientv3.WithCountOnly())
+	// Get the number of peers
+	CBLogger.Tracef("Key: %v", keyPeersInCLADNet)
+	resp, respErr := etcdClient.Get(context.TODO(), keyPeersInCLADNet, clientv3.WithPrefix(), clientv3.WithCountOnly())
 	if respErr != nil {
 		CBLogger.Error(respErr)
 	}

--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	cbnet "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/cb-network"
 	model "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/cb-network/model"
 	etcdkey "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/etcd-key"
 	"github.com/cloud-barista/cb-larva/poc-cb-net/pkg/file"
@@ -430,192 +429,6 @@ func allocatePeer(cladnetID string, hostID string, hostName string, hostIPv4CIDR
 
 }
 
-func watchPeer(wg *sync.WaitGroup, etcdClient *clientv3.Client, controllerID string) {
-	defer wg.Done()
-	// Watch "/registry/cloud-adaptive-network/host-network-information"
-	CBLogger.Debugf("Start to watch \"%v\"", etcdkey.Peer)
-
-	// Create a session to acquire a lock
-	session, _ := concurrency.NewSession(etcdClient)
-	defer session.Close()
-
-	watchChan2 := etcdClient.Watch(context.Background(), etcdkey.Peer, clientv3.WithPrefix())
-	for watchResponse := range watchChan2 {
-		for _, event := range watchResponse.Events {
-			switch event.Type {
-			case mvccpb.PUT:
-				CBLogger.Tracef("\n[cb-network controller (%s)]\nWatch - %s %q : %q",
-					controllerID, event.Type, event.Kv.Key, event.Kv.Value)
-
-				// Try to acquire a workload by multiple cb-network controllers
-				isAcquired := tryToAcquireWorkload(etcdClient, controllerID, string(event.Kv.Key), watchResponse.Header.GetRevision())
-
-				// Proceed the following by a cb-network controller acquiring the workload
-				if isAcquired {
-					// Parse HostID and CLADNetID from the Key
-					slicedKeys := strings.Split(string(event.Kv.Key), "/")
-					// parsedHostID := slicedKeys[len(slicedKeys)-1]
-					// CBLogger.Tracef("ParsedHostId: %v", parsedHostID)
-					parsedCLADNetID := slicedKeys[len(slicedKeys)-2]
-					CBLogger.Tracef("ParsedCLADNetId: %v", parsedCLADNetID)
-
-					// Prepare lock
-					keyPrefix := fmt.Sprint(etcdkey.LockPeer + "/" + parsedCLADNetID)
-
-					lock := concurrency.NewMutex(session, keyPrefix)
-					ctx := context.TODO()
-
-					// Acquire lock (or wait to have it)
-					CBLogger.Debug("Acquire a lock")
-					if err := lock.Lock(ctx); err != nil {
-						CBLogger.Error(err)
-					}
-					CBLogger.Tracef("Acquired lock for '%s'", keyPrefix)
-
-					updateNetworkingRule(parsedCLADNetID, etcdClient, controllerID)
-
-					// Release lock
-					CBLogger.Debug("Release a lock")
-					if err := lock.Unlock(ctx); err != nil {
-						CBLogger.Error(err)
-					}
-					CBLogger.Tracef("Released lock for '%s'", keyPrefix)
-				}
-
-			case mvccpb.DELETE: // The watched key has been deleted.
-				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
-			default:
-				CBLogger.Errorf("Known event (%s), Key(%q), Value(%q)", event.Type, event.Kv.Key, event.Kv.Value)
-			}
-
-		}
-	}
-	CBLogger.Debug("End.........")
-}
-
-func updateNetworkingRule(cladnetID string, etcdClient *clientv3.Client, controllerID string) {
-	CBLogger.Debug("Start.........")
-	// Get peers in a Cloud Adaptive Network
-	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
-	CBLogger.Tracef("Get - %v", keyPeersInCLADNet)
-
-	respPeers, etcdErr := etcdClient.Get(context.Background(), keyPeersInCLADNet, clientv3.WithPrefix())
-	if etcdErr != nil {
-		CBLogger.Error(etcdErr)
-	}
-	CBLogger.Tracef("GetResponse: %v", respPeers)
-	CBLogger.Tracef("The number of peers (Count): %v", respPeers.Count)
-
-	if respPeers.Count >= 2 {
-
-		// Get a specification of a cloud adaptive network
-		keyCLADNetSpec := fmt.Sprint(etcdkey.CLADNetSpecification + "/" + cladnetID)
-		CBLogger.Tracef("Get - %v", keyCLADNetSpec)
-
-		respCLADNetSpec, etcdErr := etcdClient.Get(context.Background(), keyCLADNetSpec)
-		if etcdErr != nil {
-			CBLogger.Error(etcdErr)
-		}
-		CBLogger.Tracef("GetResponse: %v", respCLADNetSpec)
-
-		var cladnetSpec model.CLADNetSpecification
-		if err := json.Unmarshal(respCLADNetSpec.Kvs[0].Value, &cladnetSpec); err != nil {
-			CBLogger.Error(err)
-		}
-		CBLogger.Tracef("The CLADNet spec: %v", cladnetSpec)
-
-		var wg sync.WaitGroup
-
-		// Set the networking rule for each peer
-		for _, kv := range respPeers.Kvs {
-			// Value
-			sourcePeerBytes := kv.Value
-			var sourcePeer model.Peer
-			if err := json.Unmarshal(sourcePeerBytes, &sourcePeer); err != nil {
-				CBLogger.Error(err)
-			}
-			CBLogger.Tracef("The source peer: %v", sourcePeer)
-
-			// Update networking rule for each peer in parallel
-			wg.Add(1)
-			CBLogger.Tracef("Update the networking rule of peer (ID: %+v, Name: %+v)", sourcePeer.HostID, sourcePeer.HostName)
-			go updateNetworkingRuleOfPeer(cladnetSpec.RuleType, sourcePeer, respPeers.Kvs, etcdClient, &wg)
-		}
-		wg.Wait()
-	}
-	CBLogger.Debug("End.........")
-}
-
-func updateNetworkingRuleOfPeer(ruleType string, sourcePeer model.Peer, peerKvs []*mvccpb.KeyValue, etcdClient *clientv3.Client, wg *sync.WaitGroup) {
-	CBLogger.Trace("Start.........")
-	defer wg.Done()
-
-	var networkingRule model.NetworkingRule
-
-	// Get the networking rule
-	keyNetworkingRuleOfPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + sourcePeer.CladnetID + "/" + sourcePeer.HostID)
-	CBLogger.Debugf("Get - %v", keyNetworkingRuleOfPeer)
-
-	respNetworkingRule, etcdErr := etcdClient.Get(context.Background(), keyNetworkingRuleOfPeer)
-	if etcdErr != nil {
-		CBLogger.Error(etcdErr)
-	}
-	CBLogger.Tracef("GetResponse: %v", respNetworkingRule)
-	CBLogger.Tracef("The number of peers (Count): %v", respNetworkingRule.Count)
-
-	if respNetworkingRule.Count > 0 {
-		err := json.Unmarshal(respNetworkingRule.Kvs[0].Value, &networkingRule)
-		if err != nil {
-			CBLogger.Error(err)
-		}
-	}
-
-	networkingRule.CladnetID = sourcePeer.CladnetID
-
-	// Create networking rule table for each peer
-	for _, peerKv := range peerKvs {
-		// Value
-		peerBytes := peerKv.Value
-		var peer model.Peer
-		if err := json.Unmarshal(peerBytes, &peer); err != nil {
-			CBLogger.Error(err)
-		}
-		CBLogger.Tracef("A peer: %v", peer)
-
-		if sourcePeer.HostID != peer.HostID {
-			// Select destination IP
-			selectedIP, peerScope, err := cbnet.SelectDestinationByRuleType(ruleType, sourcePeer, peer)
-			if err != nil {
-				CBLogger.Error(err)
-			}
-
-			CBLogger.Tracef("Selected IP: %+v", selectedIP)
-
-			networkingRule.UpdateRule(peer.HostID, peer.HostName, peer.IP, selectedIP, peerScope, peer.State)
-		}
-	}
-
-	// Transaction (compare-and-swap(CAS)) to put networking rule for a peer
-	CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfPeer)
-	networkingRuleBytes, _ := json.Marshal(networkingRule)
-	networkingRuleString := string(networkingRuleBytes)
-
-	// NOTICE: "!=" doesn't work..... It might be a temporal issue.
-	txnResp, err := etcdClient.Txn(context.TODO()).
-		If(clientv3.Compare(clientv3.Value(keyNetworkingRuleOfPeer), "=", networkingRuleString)).
-		Else(clientv3.OpPut(keyNetworkingRuleOfPeer, networkingRuleString)).
-		Commit()
-
-	if err != nil {
-		CBLogger.Error(err)
-	}
-
-	CBLogger.Tracef("TransactionResponse: %#v", txnResp)
-	CBLogger.Tracef("ResponseHeader: %#v", txnResp.Header)
-
-	CBLogger.Trace("End.........")
-}
-
 func main() {
 
 	guid := xid.New()
@@ -647,8 +460,8 @@ func main() {
 	wg.Add(1)
 	go watchHostNetworkInformation(&wg, etcdClient, controllerID)
 
-	wg.Add(1)
-	go watchPeer(&wg, etcdClient, controllerID)
+	// wg.Add(1)
+	// go watchPeer(&wg, etcdClient, controllerID)
 
 	// Waiting for all goroutines to finish
 	CBLogger.Info("Waiting for all goroutines to finish")

--- a/poc-cb-net/cmd/service/service.go
+++ b/poc-cb-net/cmd/service/service.go
@@ -215,9 +215,9 @@ func (s *serverSystemManagement) TestCloudAdaptiveNetwork(ctx context.Context, r
 	}
 
 	// Get all peers in a Cloud Adaptive Network
-	keyPeer := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
-	CBLogger.Debugf("Get - %v", keyPeer)
-	resp, err := etcdClient.Get(context.TODO(), keyPeer, clientv3.WithPrefix())
+	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
+	CBLogger.Debugf("Get - %v", keyPeersInCLADNet)
+	resp, err := etcdClient.Get(context.TODO(), keyPeersInCLADNet, clientv3.WithPrefix())
 	if err != nil {
 		CBLogger.Error(err)
 		testResponse.Message = fmt.Sprintf("error while getting the networking rule: %v\n", err)
@@ -468,8 +468,8 @@ func (s *serverCloudAdaptiveNetwork) GetPeer(ctx context.Context, req *pb.PeerRe
 	log.Printf("Received: %#v", req)
 
 	// Get a peer of the CLADNet
-	keyPeerOfCLADNet := fmt.Sprint(etcdkey.Peer + "/" + req.CladnetId + "/" + req.HostId)
-	respPeer, errEtcd := etcdClient.Get(context.Background(), keyPeerOfCLADNet)
+	keyPeer := fmt.Sprint(etcdkey.Peer + "/" + req.CladnetId + "/" + req.HostId)
+	respPeer, errEtcd := etcdClient.Get(context.Background(), keyPeer)
 	if errEtcd != nil {
 		CBLogger.Error(errEtcd)
 		return &pb.Peer{}, status.Errorf(codes.Internal, "error while getting a peer: %v", respPeer)
@@ -513,9 +513,9 @@ func (s *serverCloudAdaptiveNetwork) GetPeer(ctx context.Context, req *pb.PeerRe
 func (s *serverCloudAdaptiveNetwork) GetPeerList(ctx context.Context, req *pb.PeerRequest) (*pb.Peers, error) {
 	log.Printf("Received: %#v", req)
 
-	// Get peers of the CLADNet
-	keyPeersOfCLADNet := fmt.Sprint(etcdkey.Peer + "/" + req.CladnetId)
-	respPeers, errEtcd := etcdClient.Get(context.TODO(), keyPeersOfCLADNet, clientv3.WithPrefix())
+	// Get peers in a Cloud Adaptive Network
+	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + req.CladnetId)
+	respPeers, errEtcd := etcdClient.Get(context.TODO(), keyPeersInCLADNet, clientv3.WithPrefix())
 	if errEtcd != nil {
 		CBLogger.Error(errEtcd)
 		return nil, status.Errorf(codes.Internal, "error while getting peers: %v", respPeers)
@@ -600,8 +600,8 @@ func (s *serverCloudAdaptiveNetwork) UpdateDetailsOfPeer(ctx context.Context, re
 	doc := string(peerBytes)
 	CBLogger.Tracef("%#v", doc)
 
-	keyPeerOfCLADNet := fmt.Sprint(etcdkey.Peer + "/" + peer.CladnetId + "/" + peer.HostId)
-	_, err = etcdClient.Put(context.Background(), keyPeerOfCLADNet, doc)
+	keyPeer := fmt.Sprint(etcdkey.Peer + "/" + peer.CladnetId + "/" + peer.HostId)
+	_, err = etcdClient.Put(context.Background(), keyPeer, doc)
 	if err != nil {
 		CBLogger.Error(err)
 		return &pb.Peer{}, status.Errorf(codes.Internal, "error while updating the peer: %v", err)

--- a/poc-cb-net/cmd/service/service.go
+++ b/poc-cb-net/cmd/service/service.go
@@ -140,7 +140,7 @@ func (s *serverSystemManagement) ControlCloudAdaptiveNetwork(ctx context.Context
 		Message:     "",
 	}
 
-	// Get a networking rule of a cloud adaptive network
+	// Get all peers in a Cloud Adaptive Network
 	keyPeers := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
 	CBLogger.Debugf("Get - %v", keyPeers)
 	resp, err := etcdClient.Get(context.TODO(), keyPeers, clientv3.WithPrefix())
@@ -214,7 +214,7 @@ func (s *serverSystemManagement) TestCloudAdaptiveNetwork(ctx context.Context, r
 		testSpec = string(tempSpec)
 	}
 
-	// Get a networking rule of a cloud adaptive network
+	// Get all peers in a Cloud Adaptive Network
 	keyPeer := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
 	CBLogger.Debugf("Get - %v", keyPeer)
 	resp, err := etcdClient.Get(context.TODO(), keyPeer, clientv3.WithPrefix())

--- a/poc-cb-net/pkg/cb-network/cb-network.go
+++ b/poc-cb-net/pkg/cb-network/cb-network.go
@@ -42,7 +42,6 @@ const (
 
 // CBLogger represents a logger to show execution processes according to the logging level.
 var CBLogger *logrus.Logger
-var mutex = new(sync.Mutex)
 
 func init() {
 	fmt.Println("\nStart......... init() of cb-network.go")
@@ -97,6 +96,7 @@ type CBNetwork struct {
 	CLADNetID           string               // ID for a cloud adaptive network
 	isEncryptionEnabled bool                 // Status if encryption is applied or not.
 	NetworkingRule      model.NetworkingRule // Networking rule for a network interface and tunneling
+	networkingRuleMutex *sync.Mutex          // mutex for networking-rule
 
 	// Variables for the cb-network controller
 	// TBD
@@ -106,6 +106,7 @@ type CBNetwork struct {
 	HostName              string                    // HostName in a cloud adaptive network
 	HostPublicIP          string                    // Inquired public IP of VM/Host
 	ThisPeer              model.Peer                // Peer object for this host
+	OtherPeers            map[string]model.Peer     // Peers map for the other hosts
 	Interface             *os.File                  // Assigned cbnet0 IP from the controller
 	name                  string                    // Name of a network interface, e.g., cbnet0
 	port                  int                       // Port used for tunneling
@@ -113,7 +114,8 @@ type CBNetwork struct {
 	notificationChannel   chan bool                 // Channel to notify the status of a network interface
 	privateKey            *rsa.PrivateKey           // Private key
 	keyring               map[string]*rsa.PublicKey // Keyring for secrets
-	keyringMutex          *sync.Mutex               // Mutext for keyring
+	keyringMutex          *sync.Mutex               // Mutex for keyring
+	peersMutex            *sync.Mutex               // Mutex for peers
 	listenConnection      *net.UDPConn              // Listen connection for encapsulation and decapsulation
 
 	// Models
@@ -128,10 +130,13 @@ func New(name string, port int) *CBNetwork {
 		name:                  name,
 		port:                  port,
 		isEncryptionEnabled:   false,
+		networkingRuleMutex:   new(sync.Mutex),
+		OtherPeers:            make(map[string]model.Peer),
 		isInterfaceConfigured: false,
 		notificationChannel:   make(chan bool),
 		keyring:               make(map[string]*rsa.PublicKey),
 		keyringMutex:          new(sync.Mutex),
+		peersMutex:            new(sync.Mutex),
 	}
 	temp.UpdateHostNetworkInformation()
 
@@ -296,10 +301,10 @@ func (cbnetwork *CBNetwork) UpdateNetworkingRule(networkingRule model.Networking
 	CBLogger.Debug("Start.........")
 
 	CBLogger.Debug("Lock to update the networking rule")
-	mutex.Lock()
+	cbnetwork.networkingRuleMutex.Lock()
 	cbnetwork.NetworkingRule = networkingRule
 	CBLogger.Debug("Unlock to update the networking rule")
-	mutex.Unlock()
+	cbnetwork.networkingRuleMutex.Unlock()
 
 	CBLogger.Debug("End.........")
 }
@@ -330,8 +335,8 @@ func (cbnetwork *CBNetwork) UpdateNetworkingRule(networkingRule model.Networking
 // 	CBLogger.Debug("End.........")
 // }
 
-// State represents the state of this host (peer)
-func (cbnetwork CBNetwork) State() string {
+// ThisPeerState represents the state of this host (peer)
+func (cbnetwork CBNetwork) ThisPeerState() string {
 	CBLogger.Debugf("Current peer state: %s", cbnetwork.ThisPeer.State)
 	return cbnetwork.ThisPeer.State
 }
@@ -924,4 +929,49 @@ func selectByCostPrioritizedRule(sourcePeer model.Peer, destinationPeer model.Pe
 		err := fmt.Errorf("unknown name of cloud service provider (ProviderName: %v)", srcInfo.ProviderName)
 		return "", "", err
 	}
+}
+
+// StorePeer represents a function to add, synchronize, manage peers in local (memory)
+func (cbnetwork *CBNetwork) StorePeer(peer model.Peer) {
+	CBLogger.Debug("Start.........")
+
+	CBLogger.Debug("Lock to update peers")
+	cbnetwork.peersMutex.Lock()
+
+	// Store and synchronize peers to manage them in local
+	if peer.HostID == cbnetwork.HostID {
+		// Assign peer
+		cbnetwork.ThisPeer = peer
+
+	} else {
+		// Assign peer
+		cbnetwork.OtherPeers[peer.HostID] = peer
+	}
+
+	CBLogger.Debug("Unlock to update peers")
+	cbnetwork.peersMutex.Unlock()
+
+	CBLogger.Debug("End.........")
+}
+
+// GetPeer represents a function to find and return a peer in the local map (data structure)
+func (cbnetwork *CBNetwork) GetPeer(hostID string) (model.Peer, error) {
+	CBLogger.Debug("Start.........")
+
+	// CBLogger.Debug("Lock to update peers")
+	// cbnetwork.peersMutex.Lock()
+
+	if hostID == cbnetwork.HostID {
+		CBLogger.Debug("End.........")
+		return cbnetwork.ThisPeer, nil
+	} else {
+		tempPeer, exist := cbnetwork.OtherPeers[hostID]
+		if !exist {
+			return model.Peer{}, errors.New("could not find the peer")
+		}
+		return tempPeer, nil
+	}
+
+	// CBLogger.Debug("Unlock to update peers")
+	// cbnetwork.peersMutex.Unlock()
 }

--- a/poc-cb-net/pkg/cb-network/cb-network.go
+++ b/poc-cb-net/pkg/cb-network/cb-network.go
@@ -964,14 +964,12 @@ func (cbnetwork *CBNetwork) GetPeer(hostID string) (model.Peer, error) {
 	if hostID == cbnetwork.HostID {
 		CBLogger.Debug("End.........")
 		return cbnetwork.ThisPeer, nil
-	} else {
-		tempPeer, exist := cbnetwork.OtherPeers[hostID]
-		if !exist {
-			return model.Peer{}, errors.New("could not find the peer")
-		}
-		return tempPeer, nil
 	}
-
-	// CBLogger.Debug("Unlock to update peers")
-	// cbnetwork.peersMutex.Unlock()
+	tempPeer, exist := cbnetwork.OtherPeers[hostID]
+	if !exist {
+		CBLogger.Debug("End.........")
+		return model.Peer{}, errors.New("could not find the peer")
+	}
+	CBLogger.Debug("End.........")
+	return tempPeer, nil
 }

--- a/poc-cb-net/web/public/index.html
+++ b/poc-cb-net/web/public/index.html
@@ -696,6 +696,8 @@
             let averageRTT = parseFloat(interHostNetworkStatus[i].averageRTT);
             let latency = (averageRTT * unitCalibration).toFixed(2);
 
+            if (sourceIP == destinationIP) continue;
+
             // Check if there is network status from source to destination and vice versa
             let index = networkStatusArray.findIndex(function(item) {
                 return ((item.from == sourceIP && item.to == destinationIP) ||
@@ -749,6 +751,8 @@
             // let destinationName = interHostNetworkStatus[i].destinationName;
             let averageRTT = parseFloat(interHostNetworkStatus[i].averageRTT);
             let latency = (averageRTT * unitCalibration).toFixed(2);
+
+            if (sourceIP == destinationIP) continue;
 
             // Check if there is network status from source to destination and vice versa
             let index = networkStatusArray.findIndex(function(item) {


### PR DESCRIPTION
**The cb-network controllers** don't keep the peer information and the networking rule where the peer participates. It is stored and managed in `etcd` cluster. On the other hand, **the cb-network agent** has its own information (i.e., this peer).

So, I'm trying to move functions from the controller to the agent and simplify the related logic. I expect it's beneficial to reduce the number of I/Os and the amount of data to `etcd`.