### PR TITLE
Fix peer state update

### DIFF
--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -657,22 +657,6 @@ func updatePeerInNetworkingRule(thisPeer model.Peer, otherPeer model.Peer, ruleT
 
 	networkingRule := CBNet.NetworkingRule
 
-	// Get a specification of a cloud adaptive network
-	keyCLADNetSpec := fmt.Sprint(etcdkey.CLADNetSpecification + "/" + thisPeer.CladnetID)
-	CBLogger.Tracef("Get - %v", keyCLADNetSpec)
-
-	respCLADNetSpec, etcdErr := etcdClient.Get(context.Background(), keyCLADNetSpec)
-	if etcdErr != nil {
-		CBLogger.Error(etcdErr)
-	}
-	CBLogger.Tracef("GetResponse: %v", respCLADNetSpec)
-
-	var cladnetSpec model.CLADNetSpecification
-	if err := json.Unmarshal(respCLADNetSpec.Kvs[0].Value, &cladnetSpec); err != nil {
-		CBLogger.Error(err)
-	}
-	CBLogger.Tracef("The CLADNet spec: %v", cladnetSpec)
-
 	// Update networking rule for the peer
 
 	// Select destination IP

--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -506,7 +506,7 @@ func watchPeers(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitG
 				}
 
 				// Store peers to synchronize and use it in local
-				prevThisPeer := CBNet.ThisPeer
+				// prevThisPeer := CBNet.ThisPeer
 				CBNet.StorePeer(peer)
 
 				// Initialize or update networking rule
@@ -536,12 +536,12 @@ func watchPeers(ctx context.Context, etcdClient *clientv3.Client, wg *sync.WaitG
 
 					} else if peer.State == netstate.Tunneling {
 
-						// Update networking rule if it's not a simple state chanage of this peer
-						if prevThisPeer.State == peer.State {
-							// Update the networking rule for this peer
-							CBLogger.Debug("Update the networking rule for this peer")
-							updateNetworkingRule(CBNet.ThisPeer, CBNet.OtherPeers, ruleType, etcdClient)
-						}
+						// // Update networking rule if it's not a simple state chanage of this peer
+						// if prevThisPeer.State == peer.State {
+						// Update the networking rule for this peer
+						CBLogger.Debug("Update the networking rule for this peer")
+						updateNetworkingRule(CBNet.ThisPeer, CBNet.OtherPeers, ruleType, etcdClient)
+						// }
 
 					} else {
 						CBLogger.Debugf("Skip to update the networking rule (this peer's state: %v)", peer.State)
@@ -673,7 +673,7 @@ func updatePeerInNetworkingRule(thisPeer model.Peer, otherPeer model.Peer, ruleT
 	}
 	CBLogger.Tracef("The CLADNet spec: %v", cladnetSpec)
 
-	// Create networking rule table for each peer
+	// Update networking rule for the peer
 
 	// Select destination IP
 	selectedIP, peerScope, err := cbnet.SelectDestinationByRuleType(ruleType, thisPeer, otherPeer)


### PR DESCRIPTION
Remove the peer state check on an update of the networking rule

When a peer changes, it is pushed to all peers (i.e., they are watching). In this case, changes made by other peers should always be applied to the networking rule.