### PR TITLE
Improve logging

### DIFF
--- a/poc-cb-net/cmd/admin-web/admin-web.go
+++ b/poc-cb-net/cmd/admin-web/admin-web.go
@@ -326,7 +326,7 @@ func getExistingNetworkInfo(etcdClient *clientv3.Client) error {
 	CBLogger.Tracef("GetResponse: %#v", getResp)
 
 	fields := createFieldsForResponseSizes(*getResp)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	for _, kv := range getResp.Kvs {
 		CBLogger.Tracef("CLADNet ID: %v", kv.Key)
@@ -359,7 +359,7 @@ func getExistingNetworkInfo(etcdClient *clientv3.Client) error {
 	CBLogger.Tracef("GetResponse: %#v", respMultiSpec)
 
 	fields = createFieldsForResponseSizes(*respMultiSpec)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	if len(respMultiSpec.Kvs) != 0 {
 		var cladnetSpecificationList []string

--- a/poc-cb-net/cmd/admin-web/admin-web.go
+++ b/poc-cb-net/cmd/admin-web/admin-web.go
@@ -317,7 +317,7 @@ func handleControlCLADNet(etcdClient *clientv3.Client, responseText string) {
 func getExistingNetworkInfo(etcdClient *clientv3.Client) error {
 
 	// Get all peers
-	CBLogger.Debugf("Get - %v", etcdkey.Peer)
+	CBLogger.Debugf("Get with prefix - %v", etcdkey.Peer)
 	getResp, etcdErr := etcdClient.Get(context.Background(), etcdkey.Peer, clientv3.WithPrefix())
 	if etcdErr != nil {
 		CBLogger.Error(etcdErr)
@@ -346,7 +346,7 @@ func getExistingNetworkInfo(etcdClient *clientv3.Client) error {
 	}
 
 	// Get the specification of the CLADNet
-	CBLogger.Debugf("Get - %v", etcdkey.CLADNetSpecification)
+	CBLogger.Debugf("Get with prefix - %v", etcdkey.CLADNetSpecification)
 	respMultiSpec, err := etcdClient.Get(context.Background(), etcdkey.CLADNetSpecification, clientv3.WithPrefix())
 	if err != nil {
 		CBLogger.Error(err)
@@ -488,16 +488,17 @@ func RunEchoServer(wg *sync.WaitGroup, config model.Config) {
 }
 
 func watchPeer(wg *sync.WaitGroup, etcdClient *clientv3.Client) {
+	CBLogger.Debug("Start.........")
 	defer wg.Done()
 
 	// Watch "/registry/cloud-adaptive-network/peer"
-	CBLogger.Debugf("Start to watch \"%v\"", etcdkey.Peer)
+	CBLogger.Debugf("Watch with prefix - %v ", etcdkey.Peer)
 	watchChan1 := etcdClient.Watch(context.Background(), etcdkey.Peer, clientv3.WithPrefix())
 	for watchResponse := range watchChan1 {
 		for _, event := range watchResponse.Events {
 			switch event.Type {
 			case mvccpb.PUT: // The watched value has changed.
-				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+				CBLogger.Tracef("Pushed - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 
 				peer := event.Kv.Value
 				CBLogger.Tracef("A peer of CLADNet: %v", string(peer))
@@ -513,29 +514,30 @@ func watchPeer(wg *sync.WaitGroup, etcdClient *clientv3.Client) {
 				}
 
 			case mvccpb.DELETE: // The watched key has been deleted.
-				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+				CBLogger.Tracef("Pushed - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 			default:
 				CBLogger.Errorf("Known event (%s), Key(%q), Value(%q)", event.Type, event.Kv.Key, event.Kv.Value)
 			}
 		}
 	}
-	CBLogger.Debugf("End to watch \"%v\"", etcdkey.Peer)
+	CBLogger.Debug("End.........")
 }
 
 func watchCLADNetSpecification(wg *sync.WaitGroup, etcdClient *clientv3.Client) {
+	CBLogger.Debug("Start.........")
 	defer wg.Done()
 
 	// It doesn't work for the time being
 	// Watch "/registry/cloud-adaptive-network/cladnet-specification"
-	CBLogger.Debugf("Start to watch \"%v\"", etcdkey.CLADNetSpecification)
+	CBLogger.Debugf("Watch with prefix - %v ", etcdkey.CLADNetSpecification)
 	watchChan1 := etcdClient.Watch(context.Background(), etcdkey.CLADNetSpecification, clientv3.WithPrefix())
 	for watchResponse := range watchChan1 {
 		for _, event := range watchResponse.Events {
-			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+			CBLogger.Tracef("Pushed - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 			CBLogger.Tracef("Updated CLADNet: %v", string(event.Kv.Value))
 
 			// Get the specification of the CLADNet
-			CBLogger.Debugf("Get - %v", etcdkey.CLADNetSpecification)
+			CBLogger.Debugf("Get with prefix - %v", etcdkey.CLADNetSpecification)
 			respMultiSpec, err := etcdClient.Get(context.Background(), etcdkey.CLADNetSpecification, clientv3.WithPrefix())
 			if err != nil {
 				CBLogger.Error(err)
@@ -568,18 +570,18 @@ func watchCLADNetSpecification(wg *sync.WaitGroup, etcdClient *clientv3.Client) 
 			}
 		}
 	}
-	CBLogger.Debugf("End to watch \"%v\"", etcdkey.CLADNetSpecification)
+	CBLogger.Debug("End.........")
 }
 
 func watchStatusInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client) {
 	defer wg.Done()
 
 	// Watch "/registry/cloud-adaptive-network/status/information/{cladnet-id}/{host-id}"
-	CBLogger.Debugf("Start to watch \"%v\"", etcdkey.StatusInformation)
+	CBLogger.Debugf("Watch with prefix - %v", etcdkey.StatusInformation)
 	watchChan1 := etcdClient.Watch(context.Background(), etcdkey.StatusInformation, clientv3.WithPrefix())
 	for watchResponse := range watchChan1 {
 		for _, event := range watchResponse.Events {
-			CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+			CBLogger.Tracef("Pushed - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 			slicedKeys := strings.Split(string(event.Kv.Key), "/")
 			parsedHostID := slicedKeys[len(slicedKeys)-1]
 			CBLogger.Tracef("ParsedHostID: %v", parsedHostID)
@@ -598,7 +600,7 @@ func watchStatusInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client) {
 			}
 		}
 	}
-	CBLogger.Debugf("End to watch \"%v\"", etcdkey.Status)
+	CBLogger.Debug("End.........")
 }
 
 func main() {

--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -485,7 +485,7 @@ func initializeSecret(etcdClient *clientv3.Client) {
 	CBLogger.Tracef("GetResponse: %#v", getResp)
 
 	fields := createFieldsForResponseSizes(*getResp)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	// Set the other hosts' secrets
 	for _, kv := range getResp.Kvs {
@@ -641,7 +641,7 @@ func getRuleType(etcdClient *clientv3.Client) (string, error) {
 	CBLogger.Tracef("GetResponse: %#v", respCLADNetSpec)
 
 	fields := createFieldsForResponseSizes(*respCLADNetSpec)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	var cladnetSpec model.CLADNetSpecification
 	if err := json.Unmarshal(respCLADNetSpec.Kvs[0].Value, &cladnetSpec); err != nil {
@@ -847,7 +847,7 @@ func main() {
 	CBLogger.Tracef("GetResponse: %#v", getResp)
 
 	fields := createFieldsForResponseSizes(*getResp)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	for _, kv := range getResp.Kvs {
 		key := string(kv.Key)

--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -326,13 +326,17 @@ func checkConnectivity(data string, etcdClient *clientv3.Client) {
 	// Put the network status of the CLADNet to the etcd
 	// Key: /registry/cloud-adaptive-network/status/information/{cladnet-id}/{host-id}
 	keyStatusInformation := fmt.Sprint(etcdkey.StatusInformation + "/" + cladnetID + "/" + hostID)
-	CBLogger.Debugf("Put - %v", keyStatusInformation)
 
-	strNetworkStatus, _ := json.Marshal(networkStatus)
-	size := binary.Size(strNetworkStatus)
+	networkStatusBytes, _ := json.Marshal(networkStatus)
+	networkStatueStr := string(networkStatusBytes)
+
+	CBLogger.Debugf("Put - %v", keyStatusInformation)
+	CBLogger.Tracef("Value: %#v", networkStatus)
+
+	size := binary.Size(networkStatusBytes)
 	CBLogger.WithField("total size", size).Tracef("PutRequest size (bytes)")
 
-	putResp, err := etcdClient.Put(context.Background(), keyStatusInformation, string(strNetworkStatus))
+	putResp, err := etcdClient.Put(context.Background(), keyStatusInformation, networkStatueStr)
 	if err != nil {
 		CBLogger.Error(err)
 	}
@@ -387,16 +391,16 @@ func initializeAgent(etcdClient *clientv3.Client) {
 	CBNet.UpdateHostNetworkInformation()
 	temp := CBNet.GetHostNetworkInformation()
 	currentHostNetworkInformationBytes, _ := json.Marshal(temp)
-	currentHostNetworkInformation := string(currentHostNetworkInformationBytes)
-	CBLogger.Trace(currentHostNetworkInformation)
+	currentHostNetworkInformationStr := string(currentHostNetworkInformationBytes)
 
 	keyHostNetworkInformation := fmt.Sprint(etcdkey.HostNetworkInformation + "/" + cladnetID + "/" + hostID)
 	CBLogger.Debugf("Put - %v", keyHostNetworkInformation)
+	CBLogger.Tracef("Value %#v", temp)
 
 	size := binary.Size(currentHostNetworkInformationBytes)
 	CBLogger.WithField("total size", size).Tracef("PutRequest size (bytes)")
 
-	putResp, err := etcdClient.Put(context.TODO(), keyHostNetworkInformation, currentHostNetworkInformation)
+	putResp, err := etcdClient.Put(context.TODO(), keyHostNetworkInformation, currentHostNetworkInformationStr)
 	if err != nil {
 		CBLogger.Error(err)
 	}
@@ -413,13 +417,16 @@ func updatePeerState(state string, etcdClient *clientv3.Client) {
 
 	keyPeer := fmt.Sprint(etcdkey.Peer + "/" + CBNet.CLADNetID + "/" + CBNet.HostID)
 
-	CBLogger.Debugf("Put - %v", keyPeer)
-	doc, _ := json.Marshal(tempPeer)
+	peerBytes, _ := json.Marshal(tempPeer)
+	peerStr := string(peerBytes)
 
-	size := binary.Size(doc)
+	CBLogger.Debugf("Put - %v", keyPeer)
+	CBLogger.Tracef("Value: %#v", tempPeer)
+
+	size := binary.Size(peerBytes)
 	CBLogger.WithField("total size", size).Tracef("PutRequest size (bytes)")
 
-	putResp, err := etcdClient.Put(context.TODO(), keyPeer, string(doc))
+	putResp, err := etcdClient.Put(context.TODO(), keyPeer, peerStr)
 	if err != nil {
 		CBLogger.Error(err)
 	}
@@ -689,9 +696,10 @@ func updateNetworkingRule(thisPeer model.Peer, otherPeers map[string]model.Peer,
 
 		// Transaction (compare-and-swap(CAS)) to put networking rule for a peer
 		keyNetworkingRuleOfThisPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + thisPeer.CladnetID + "/" + thisPeer.HostID)
-		CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
 		networkingRuleBytes, _ := json.Marshal(networkingRule)
 		networkingRuleString := string(networkingRuleBytes)
+		CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
+		CBLogger.Tracef("Value: %#v", networkingRule)
 
 		size := binary.Size(networkingRuleBytes)
 		CBLogger.WithField("total size", size).Tracef("TransactionRequest size (bytes)")
@@ -735,9 +743,10 @@ func updatePeerInNetworkingRule(thisPeer model.Peer, otherPeer model.Peer, ruleT
 
 	// Transaction (compare-and-swap(CAS)) to put networking rule for a peer
 	keyNetworkingRuleOfThisPeer := fmt.Sprint(etcdkey.NetworkingRule + "/" + thisPeer.CladnetID + "/" + thisPeer.HostID)
-	CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
 	networkingRuleBytes, _ := json.Marshal(networkingRule)
 	networkingRuleString := string(networkingRuleBytes)
+	CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
+	CBLogger.Tracef("Value: %#v", networkingRule)
 
 	size := binary.Size(networkingRuleBytes)
 	CBLogger.WithField("total size", size).Tracef("TransactionRequest size (bytes)")

--- a/poc-cb-net/cmd/agent/agent.go
+++ b/poc-cb-net/cmd/agent/agent.go
@@ -693,6 +693,9 @@ func updateNetworkingRule(thisPeer model.Peer, otherPeers map[string]model.Peer,
 		networkingRuleBytes, _ := json.Marshal(networkingRule)
 		networkingRuleString := string(networkingRuleBytes)
 
+		size := binary.Size(networkingRuleBytes)
+		CBLogger.WithField("total size", size).Tracef("TransactionRequest size (bytes)")
+
 		// NOTICE: "!=" doesn't work..... It might be a temporal issue.
 		txnResp, err := etcdClient.Txn(context.TODO()).
 			If(clientv3.Compare(clientv3.Value(keyNetworkingRuleOfThisPeer), "=", networkingRuleString)).
@@ -735,6 +738,9 @@ func updatePeerInNetworkingRule(thisPeer model.Peer, otherPeer model.Peer, ruleT
 	CBLogger.Debugf("Transaction (compare-and-swap(CAS)) - %v", keyNetworkingRuleOfThisPeer)
 	networkingRuleBytes, _ := json.Marshal(networkingRule)
 	networkingRuleString := string(networkingRuleBytes)
+
+	size := binary.Size(networkingRuleBytes)
+	CBLogger.WithField("total size", size).Tracef("TransactionRequest size (bytes)")
 
 	// NOTICE: "!=" doesn't work..... It might be a temporal issue.
 	txnResp, err := etcdClient.Txn(context.TODO()).

--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -205,15 +205,16 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 						peer.State = netstate.Configuring
 					}
 
+					peerBytes, _ := json.Marshal(peer)
+					peerStr := string(peerBytes)
+
 					CBLogger.Debugf("Put - %v", keyPeer)
 					CBLogger.Tracef("Value: %#v", peer)
 
-					doc, _ := json.Marshal(peer)
-
-					size := binary.Size(doc)
+					size := binary.Size(peerBytes)
 					CBLogger.WithField("total size", size).Tracef("PutRequest size (bytes)")
 
-					putResp, err := etcdClient.Put(context.TODO(), keyPeer, string(doc))
+					putResp, err := etcdClient.Put(context.TODO(), keyPeer, peerStr)
 					if err != nil {
 						CBLogger.Error(err)
 					}

--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -118,14 +118,14 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 	defer session.Close()
 
 	// Watch "/registry/cloud-adaptive-network/host-network-information"
-	CBLogger.Debugf("Start to watch \"%v\"", etcdkey.HostNetworkInformation)
+	CBLogger.Debugf("Watch with prefix - %v", etcdkey.HostNetworkInformation)
 
 	watchChan2 := etcdClient.Watch(context.Background(), etcdkey.HostNetworkInformation, clientv3.WithPrefix())
 	for watchResponse := range watchChan2 {
 		for _, event := range watchResponse.Events {
 			switch event.Type {
 			case mvccpb.PUT: // The watched value has changed.
-				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+				CBLogger.Tracef("Pushed - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 
 				// Try to acquire a workload by multiple cb-network controllers
 				isAcquired := tryToAcquireWorkload(etcdClient, string(event.Kv.Key), watchResponse.Header.GetRevision())
@@ -223,7 +223,7 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 				}
 
 			case mvccpb.DELETE: // The watched key has been deleted.
-				CBLogger.Tracef("Watch - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
+				CBLogger.Tracef("Pushed - %s %q : %q", event.Type, event.Kv.Key, event.Kv.Value)
 			default:
 				CBLogger.Errorf("Known event (%s), Key(%q), Value(%q)", event.Type, event.Kv.Key, event.Kv.Value)
 			}
@@ -378,7 +378,7 @@ func allocatePeer(cladnetID string, hostID string, hostName string, hostIPv4CIDR
 	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
 
 	// Get the number of peers
-	CBLogger.Debugf("Get - %v", keyPeersInCLADNet)
+	CBLogger.Debugf("Get with prefix - %v", keyPeersInCLADNet)
 	resp, respErr := etcdClient.Get(context.TODO(), keyPeersInCLADNet, clientv3.WithPrefix(), clientv3.WithCountOnly())
 	if respErr != nil {
 		CBLogger.Error(respErr)

--- a/poc-cb-net/cmd/controller/controller.go
+++ b/poc-cb-net/cmd/controller/controller.go
@@ -183,7 +183,7 @@ func watchHostNetworkInformation(wg *sync.WaitGroup, etcdClient *clientv3.Client
 					CBLogger.Tracef("GetResponse: %#v", respRule)
 
 					fields := createFieldsForResponseSizes(*respRule)
-					CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+					CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 					var peer model.Peer
 
@@ -302,7 +302,7 @@ func getIpv4AddressSpace(etcdClient *clientv3.Client, key string) (string, error
 	CBLogger.Tracef("GetResponse: %#v", respSpec)
 
 	fields := createFieldsForResponseSizes(*respSpec)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	var tempSpec model.CLADNetSpecification
 
@@ -397,7 +397,7 @@ func allocatePeer(cladnetID string, hostID string, hostName string, hostIPv4CIDR
 	CBLogger.Tracef("GetResponse: %#v", resp)
 
 	fields := createFieldsForResponseSizes(*resp)
-	CBLogger.WithFields(fields).Tracef("GetReponse size (bytes)")
+	CBLogger.WithFields(fields).Tracef("GetResponse size (bytes)")
 
 	state := netstate.Configuring
 	peerIPv4CIDR, peerIPAddress, err := assignIPAddressToPeer(cladnetIpv4AddressSpace, uint32(resp.Count+2))

--- a/poc-cb-net/cmd/service/service.go
+++ b/poc-cb-net/cmd/service/service.go
@@ -152,7 +152,7 @@ func (s *serverSystemManagement) ControlCloudAdaptiveNetwork(ctx context.Context
 
 	// Get all peers in a Cloud Adaptive Network
 	keyPeers := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
-	CBLogger.Debugf("Get - %v", keyPeers)
+	CBLogger.Debugf("Get with prefix - %v", keyPeers)
 	getResp, err := etcdClient.Get(context.TODO(), keyPeers, clientv3.WithPrefix())
 	if err != nil {
 		CBLogger.Error(err)
@@ -228,7 +228,7 @@ func (s *serverSystemManagement) TestCloudAdaptiveNetwork(ctx context.Context, r
 
 	// Get all peers in a Cloud Adaptive Network
 	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + cladnetID)
-	CBLogger.Debugf("Get - %v", keyPeersInCLADNet)
+	CBLogger.Debugf("Get with prefix - %v", keyPeersInCLADNet)
 	getResp, err := etcdClient.Get(context.TODO(), keyPeersInCLADNet, clientv3.WithPrefix())
 	if err != nil {
 		CBLogger.Error(err)
@@ -314,7 +314,7 @@ func (s *serverCloudAdaptiveNetwork) GetCLADNet(ctx context.Context, req *pb.CLA
 
 func (s *serverCloudAdaptiveNetwork) GetCLADNetList(ctx context.Context, in *empty.Empty) (*pb.CLADNetSpecifications, error) {
 	// Get all specification of the CLADNet
-	CBLogger.Debugf("Get - %v", etcdkey.CLADNetSpecification)
+	CBLogger.Debugf("Get with prefix - %v", etcdkey.CLADNetSpecification)
 	respSpecs, errSpec := etcdClient.Get(context.Background(), etcdkey.CLADNetSpecification, clientv3.WithPrefix())
 	if errSpec != nil {
 		CBLogger.Error(errSpec)
@@ -537,7 +537,7 @@ func (s *serverCloudAdaptiveNetwork) GetPeerList(ctx context.Context, req *pb.Pe
 
 	// Get peers in a Cloud Adaptive Network
 	keyPeersInCLADNet := fmt.Sprint(etcdkey.Peer + "/" + req.CladnetId)
-	CBLogger.Debugf("Get - %v", keyPeersInCLADNet)
+	CBLogger.Debugf("Get with prefix - %v", keyPeersInCLADNet)
 	respPeers, errEtcd := etcdClient.Get(context.TODO(), keyPeersInCLADNet, clientv3.WithPrefix())
 	if errEtcd != nil {
 		CBLogger.Error(errEtcd)

--- a/poc-cb-net/pkg/cb-network/cb-network.go
+++ b/poc-cb-net/pkg/cb-network/cb-network.go
@@ -867,7 +867,7 @@ func (cbnetwork *CBNetwork) ConfigureHostID() error {
 
 // SelectDestinationByRuleType represents a function to set a unique host ID
 func SelectDestinationByRuleType(ruleType string, sourcePeer model.Peer, destinationPeer model.Peer) (string, string, error) {
-	CBLogger.Tracef("Start.........")
+	CBLogger.Debug("Start.........")
 
 	var err error
 
@@ -889,7 +889,7 @@ func SelectDestinationByRuleType(ruleType string, sourcePeer model.Peer, destina
 		CBLogger.Error(err)
 	}
 
-	CBLogger.Tracef("End.........")
+	CBLogger.Debug("End.........")
 	return destinationPeer.HostPublicIP, "inter", err
 }
 


### PR DESCRIPTION
- Log key, value, and byte size of `etcd` request and response  
- Log `etcd` keys and the pushed values on watching
- Log the elapsed time for locking
- Specify `WithPrefix` on the log message