### PR TITLE
Chagne the log file path

### DIFF
--- a/poc-cb-net/config/template-log_conf.yaml
+++ b/poc-cb-net/config/template-log_conf.yaml
@@ -12,7 +12,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/1.deploy-cb-network-agent.sh
+++ b/poc-cb-net/scripts/1.deploy-cb-network-agent.sh
@@ -95,7 +95,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/2.re-deploy-cb-network-agent.sh
+++ b/poc-cb-net/scripts/2.re-deploy-cb-network-agent.sh
@@ -106,7 +106,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/build-and-run-agent-in-the-background.sh
+++ b/poc-cb-net/scripts/build-and-run-agent-in-the-background.sh
@@ -145,7 +145,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/build-and-run-agent.sh
+++ b/poc-cb-net/scripts/build-and-run-agent.sh
@@ -145,7 +145,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/deploy-the-released-cb-network-agent.sh
+++ b/poc-cb-net/scripts/deploy-the-released-cb-network-agent.sh
@@ -92,7 +92,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/get-and-run-agent.sh
+++ b/poc-cb-net/scripts/get-and-run-agent.sh
@@ -95,7 +95,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50

--- a/poc-cb-net/scripts/redeploy-the-released-cb-network-agent.sh
+++ b/poc-cb-net/scripts/redeploy-the-released-cb-network-agent.sh
@@ -103,7 +103,7 @@ cblog:
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: /var/log/cblogs.log
   #  filename: $CBLOG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50


### PR DESCRIPTION
from "./log/cblogs.log" to "/var/log/cblogs.log"

It's necessary for the cb-network system to integrate with the distributed logging system (i.e., Elastic Stack) in a loosely-coupled manner.